### PR TITLE
add:アカウント編集＆削除機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,11 +6,12 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::RoutingError, with: :render_404
   rescue_from StandardError, with: :render_500
 
+  private
+
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :username ])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :username ])
   end
-
-  private
 
   # 404エラーを public/404.html に接続
   def render_404(exception = nil)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  protected
+
+  def update_resource(resource, params)
+    resource.update_without_password(params)
+  end
+end

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,35 @@
-<h2>Change your password</h2>
+<% content_for :title, "Change your password" %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+<div class="sm:mx-auto sm:w-full sm:max-w-lg">
+  <h2 class="mt-2 text-center text-2xl sm:text-3xl font-bold tracking-tight text-gray-900">
+    Change your password
+  </h2>
+</div>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
+<div class="mt-4 sm:mx-auto sm:w-full sm:max-w-lg">
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
+    <div class="mt-4">
+      <%= f.label :password, "New password", class: "block text-lg sm:text-xl font-medium text-gray-900" %>
+      <% if @minimum_password_length %>
+        <em class="text-sm text-gray-500">(<%= @minimum_password_length %> characters minimum)</em>
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "mt-2 block w-full rounded-md bg-white px-3 py-2 text-base text-gray-900 border border-gray-300 focus:outline-indigo-600" %>
+    </div>
 
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
+    <div class="mt-4">
+      <%= f.label :password_confirmation, "Confirm new password", class: "block text-lg sm:text-xl font-medium text-gray-900" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-2 block w-full rounded-md bg-white px-3 py-2 text-base text-gray-900 border border-gray-300 focus:outline-indigo-600" %>
+    </div>
 
-<%= render "devise/shared/links" %>
+    <div class="mt-6">
+      <%= f.submit "Change my password", class: "flex w-full justify-center rounded-md bg-indigo-600 px-4 py-2 text-base font-semibold text-white shadow-xs hover:bg-indigo-500 focus:outline-2 focus:outline-indigo-600" %>
+    </div>
+
+    <div class="mt-2 text-center text-base sm:text-lg text-gray-500">
+      <%= render "devise/shared/links" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,43 +1,52 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<% content_for :title, "Edit your account" %>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+<div class="sm:mx-auto sm:w-full sm:max-w-lg">
+  <h2 class="mt-2 text-center text-2xl sm:text-3xl font-bold tracking-tight text-gray-900">
+    Edit your account
+  </h2>
+</div>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
+<div class="mt-4 sm:mx-auto sm:w-full sm:max-w-lg">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <div class="mt-4">
+      <%= f.label :username, class: "block text-lg sm:text-xl font-medium text-gray-900" %>
+      <%= f.text_field :username, autofocus: true, autocomplete: "username", class: "mt-2 block w-full rounded-md bg-white px-3 py-2 text-base text-gray-900 border border-gray-300 focus:outline-indigo-600" %>
+    </div>
+
+    <div class="mt-4">
+      <%= f.label :email, class: "block text-lg sm:text-xl font-medium text-gray-900" %>
+      <%= f.email_field :email, autocomplete: "email", class: "mt-2 block w-full rounded-md bg-white px-3 py-2 text-base text-gray-900 border border-gray-300 focus:outline-indigo-600" %>
+    </div>
+
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %> 
+      <div class="mt-2 text-sm text-gray-600">
+        Currently waiting confirmation for: <%= resource.unconfirmed_email %>
+      </div>
+    <% end %>
+
+    <div class="mt-6">
+      <%= f.submit "Update", class: "flex w-full justify-center rounded-md bg-indigo-600 px-4 py-2 text-base font-semibold text-white shadow-xs hover:bg-indigo-500 focus:outline-2 focus:outline-indigo-600" %>
+    </div>
   <% end %>
 
-  <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
-    <%= f.password_field :password, autocomplete: "new-password" %>
-    <% if @minimum_password_length %>
-      <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+  <div class="mt-8 border-t border-gray-200 pt-6 text-center">
+    <h3 class="text-lg font-semibold text-gray-700 mb-2">Cancel my account</h3>
+    <%= form_with url: registration_path(resource_name), method: :delete, html: { id: "delete-account-form" } do %>
+      <button type="button" onclick="confirmDelete()" class="text-red-600 hover:text-red-500 text-base hover:underline">
+        Cancel my account
+      </button>
     <% end %>
+
+  <script>
+  function confirmDelete() {
+    if (confirm("本当にアカウントを削除しますか？")) {
+      document.getElementById("delete-account-form").submit();
+    }
+  }
+</script>
+
+<div class="mt-4 text-center text-base sm:text-lg text-gray-500">
+    <%= link_to "トップページに戻る", root_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
-    <%= f.password_field :current_password, autocomplete: "current-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Update" %>
-  </div>
-<% end %>
-
-<h3>Cancel my account</h3>
-
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
-
-<%= link_to "Back", :back %>

--- a/app/views/positive_words/index.html.erb
+++ b/app/views/positive_words/index.html.erb
@@ -35,11 +35,11 @@
 <% end %>
 
 <p class="text-center mt-10">
-  <%= link_to "トップページに戻る", root_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400' %>
+  <%= link_to "トップページに戻る", root_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
 </p>
 
 <div class="mt-4 text-center">
-  <%= link_to "ポジティブワードを振り返る(ユーザーページ)", userpages_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400' %>
+  <%= link_to "ポジティブワードを振り返る(ユーザーページ)", userpages_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
 </div>
 
 <div class="mt-6 text-center">

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -12,16 +12,22 @@
     </h4>
 
     <div class="mt-4 text-center">
-      <%= link_to "ポジティブワードを知る", positive_words_path, class: 'text-base sm:text-lg text-blue-500 font-semibold hover:text-blue-400' %>
+      <%= link_to "ポジティブワードを知る", positive_words_path, class: 'text-base sm:text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
     </div>
 
     <div class="mt-3 text-center">
-      <%= link_to "ポジティブワードを振り返る(ユーザーページ)", userpages_path, class: 'text-base sm:text-lg text-blue-500 font-semibold hover:text-blue-400' %>
+      <%= link_to "ポジティブワードを振り返る(ユーザーページ)", userpages_path, class: 'text-base sm:text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
+    </div>
+    
+    <div class="mt-4 text-center">
+      <%= link_to "アカウント編集", edit_user_registration_path, class: 'inline-block text-sm sm:text-base font-medium text-white bg-indigo-600 hover:bg-indigo-500 px-3 py-2 rounded-md' %>
     </div>
 
     <div class="mt-4 text-center">
       <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'inline-block text-sm font-medium text-white bg-red-700 hover:bg-red-700 px-3 py-2 rounded-md' %>
     </div>
+
+
 
     <% else %>
     <h3 class="mt-8 text-center text-2xl sm:text-3xl font-semibold text-gray-900">

--- a/app/views/userpages/index.html.erb
+++ b/app/views/userpages/index.html.erb
@@ -6,12 +6,17 @@
 
 <div class="mt-4 sm:mx-auto sm:w-full sm:max-w-lg">
   <div class="mt-6 text-center">
-    <%= link_to "トップページに戻る", root_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400' %>
+    <%= link_to "トップページに戻る", root_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
   </div>
 
   <div class="mt-6 text-center">
-    <%= link_to "ポジティブワードを知る", positive_words_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400' %>
+    <%= link_to "ポジティブワードを知る", positive_words_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-400 hover:underline' %>
   </div>
+
+  <div class="mt-4 text-center">
+  <%= link_to "アカウント編集", edit_user_registration_path, class: 'inline-block text-sm sm:text-base font-medium text-white bg-indigo-600 hover:bg-indigo-500 px-3 py-2 rounded-md' %>
+  </div>
+
 
   <div class="mt-6 text-center">
     <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'inline-block text-sm font-medium text-white bg-red-700 hover:bg-red-700 px-4 py-2 rounded-md' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: "users/registrations"
+  }
   get "top/index"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 


### PR DESCRIPTION
# 概要
**卒業制作⑧基本的機能の実装(ログイン周り)**
アカウント編集＆削除機能の追加

# 実装内容
- [x] ログイン後、トップページ、ユーザーページにアカウント編集できるリンクを設置
- [x] Deviseの標準である/users/editのUIを他のぺージと同じようにカスタマイズ
- [x] パスワードなしでユーザー名・メールアドレスを更新できるように変更
- Users::RegistrationsController を作成し、update_resource をオーバーライド
- update_without_password メソッドを User モデルに実装
- [x] アカウント削除時に確認モーダルを挟むよう実装（誤操作防止）
- [x] /users/password/editのUIを他のぺージと同じようにカスタマイズ

# 確認方法
- [x] 「アカウント編集」から /users/edit に遷移できる
- [x]  ユーザー名・メールアドレスを変更後、トップページに戻って反映されているか
- [x] 「Cancel my account」クリック時、確認モーダルが表示され、「はい」でアカウント削除されるか
- [x] 削除後、同じアカウントではログインできないこと
- [x]  /users/password/edit ページのデザインが他と統一されていること

# その他
トップページなどのリンクにホバー時のアンダーラインを追加し、UXを強化（視認性UP）しました。

# ISSUE
**Closes #46  **