### PR TITLE
メッセージのお気に入り登録

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,5 +74,5 @@ gem "sentry-rails"
 gem "tailwindcss-ruby", "~> 4.0"
 
 gem "tailwindcss-rails", "~> 4.2"
-gem 'dotenv-rails'       # APIキーの.env管理に
-gem 'ruby-openai'        # OpenAIのAPIラッパー
+gem "dotenv-rails"       # APIキーの.env管理に
+gem "ruby-openai"        # OpenAIのAPIラッパー

--- a/app/controllers/ai_messages_controller.rb
+++ b/app/controllers/ai_messages_controller.rb
@@ -2,44 +2,86 @@ class AiMessagesController < ApplicationController
   before_action :authenticate_user!
 
   def new
+    @word_id = params[:word_id]
+    @target = params[:target]
+    @situation = params[:situation]
+
+    @positive_word = PositiveWord.find_by(id: @word_id) || PositiveWord.new
   end
 
   def generate
-    # ユーザーが1日に3回まで生成できるように制限をかける
     if user_reached_limit?
       respond_to do |format|
-        format.html { redirect_to new_ai_message_path(error: '一日の生成回数制限に達しました(上限3回)') }
-        format.json { render json: { error: '一日の生成回数制限に達しました(上限3回)' }, status: :forbidden }
+        format.html {
+          redirect_to new_ai_message_path(error: "一日の生成回数制限に達しました(上限3回)")
+        }
+        format.json {
+          render json: { error: "一日の生成回数制限に達しました(上限3回)" }, status: :forbidden
+        }
       end
       return
     end
 
-    target = Target.find_or_create_by(name: params[:target])
-    situation = Situation.find_or_create_by(name: params[:situation])
+    target_name = params[:positive_word][:target].to_s.strip
+    situation_name = params[:positive_word][:situation].to_s.strip
 
-    prompt = "#{target.name}が#{situation.name}ときに贈る、ほめたり、肯定したりなどポジティブになれる会話文のような短いメッセージを1つ考えてください。出力はそのメッセージ本文のみを日本語で返してください。番号付け、複数回答、説明や挨拶などは不要です。過去に生成されたメッセージと重複しないようにしてください。"
+    if target_name.blank? || situation_name.blank?
+      respond_to do |format|
+        format.html {
+          redirect_to new_ai_message_path(error: "対象人物とシチュエーションは必須です。")
+        }
+        format.json {
+          render json: { error: "対象人物とシチュエーションは必須です。" }, status: :unprocessable_entity
+        }
+      end
+      return
+    end
 
-     client = OpenAI::Client.new
-     response = client.chat(
-       parameters: {
-         model: "gpt-4.1-mini",
-         messages: [{ role: "user", content: prompt }],
-         temperature: 0.8
-       }
-     )
-     @message = response.dig("choices", 0, "message", "content")
-    
-    current_user.positive_words.create(target: target, situation: situation, word: @message)
+    target = Target.find_or_create_by(name: target_name)
+    situation = Situation.find_or_create_by(name: situation_name)
 
-    respond_to do |format|
-      format.html { redirect_to new_ai_message_path(message: @message, target: params[:target], situation: params[:situation]) }
-      format.json { render json: { word: @message } }
+    @positive_word = PositiveWord.new(
+      target: target,
+      situation: situation,
+      user: current_user
+    )
+
+    if @positive_word.valid?
+      prompt = "#{target.name}が#{situation.name}ときに贈る、ほめたり、肯定したりなどポジティブになれる会話文のような短いメッセージを1つ考えてください。出力はそのメッセージ本文のみを日本語で返してください。番号付け、複数回答、説明や挨拶などは不要です。過去に生成されたメッセージと重複しないようにしてください。"
+
+      client = OpenAI::Client.new
+      response = client.chat(
+        parameters: {
+          model: "gpt-4.1-mini",
+          messages: [ { role: "user", content: prompt } ],
+          temperature: 0.8
+        }
+      )
+
+      ai_message = response.dig("choices", 0, "message", "content")
+
+      @positive_word.word = ai_message
+      @positive_word.save!
+
+      respond_to do |format|
+        format.html {
+          redirect_to new_ai_message_path(
+            word_id: @positive_word.id,
+            target: params[:positive_word][:target],
+            situation: params[:positive_word][:situation]
+          )
+        }
+        format.json {
+          render json: { word_id: @positive_word.id }
+        }
+      end
+    else
+      render :new, status: :unprocessable_entity
     end
   end
 
   private
 
-  # ユーザーが1日にメッセージ生成を3回以上行っていないかチェック
   def user_reached_limit?
     current_user.positive_words.where(created_at: Time.zone.today.all_day).count >= 3
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,5 +8,4 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:sign_up, keys: [ :username ])
     devise_parameter_sanitizer.permit(:account_update, keys: [ :username ])
   end
-
 end

--- a/app/controllers/word_favorites_controller.rb
+++ b/app/controllers/word_favorites_controller.rb
@@ -1,0 +1,13 @@
+class WordFavoritesController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    @positive_word = PositiveWord.find(params[:positive_word_id])
+    current_user.bookmark(@positive_word)
+  end
+
+  def destroy
+    @positive_word = current_user.word_favorites.find(params[:id]).positive_word
+    current_user.unbookmark(@positive_word)
+  end
+end

--- a/app/helpers/word_favorites_helper.rb
+++ b/app/helpers/word_favorites_helper.rb
@@ -1,0 +1,2 @@
+module WordFavoritesHelper
+end

--- a/app/javascript/ai_messages.js
+++ b/app/javascript/ai_messages.js
@@ -1,20 +1,16 @@
-document.addEventListener('DOMContentLoaded', () => {
-  console.log("DOMContentLoaded 起動しました");
+document.addEventListener('turbo:load', () => {
 
   const form = document.getElementById('generate-form');
+  if (!form) return;
+
+  if (form.dataset.listenerAttached === "true") return;
+
   const resultContainer = document.getElementById('result-container');
   const aiMessage = document.getElementById('ai-message');
   const regenerateButton = document.getElementById('regenerate-button');
 
-  if (!form) {
-    console.error('generate-formが見つかりません');
-    return;
-  }
-
   form.addEventListener('ajax:success', (event) => {
-    console.log("ajax:success イベント発火");
     const [data, status, xhr] = event.detail;
-    console.log('受信データ:', data);
 
     if (data && data.word) {
       aiMessage.textContent = data.word;
@@ -27,10 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
   if (regenerateButton) {
     regenerateButton.addEventListener('click', (e) => {
       e.preventDefault();
-      if (resultContainer) {
-        resultContainer.style.display = 'none';
-      }
-      // form.reset(); // これをコメントアウトすると、フォームの内容が保持されたままになります
+      resultContainer.style.display = 'none';
     });
   }
+
+  form.dataset.listenerAttached = "true";
 });

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,1 +1,2 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
+import "@hotwired/turbo-rails"

--- a/app/javascript/situations.js
+++ b/app/javascript/situations.js
@@ -1,32 +1,35 @@
-document.addEventListener('DOMContentLoaded', () => {
-    const allSituations = JSON.parse(document.getElementById('situations-data').dataset.situations);
-    const targetSelect = document.getElementById('target_id');
-    const situationSelect = document.getElementById('situation_id');
-    const situationContainer = document.getElementById('situation-container');
-  
-    function updateSituationsForTarget(targetId) {
+document.addEventListener('turbo:load', () => {
+  const dataElement = document.getElementById('situations-data');
+  if (!dataElement) return;
+
+  const allSituations = JSON.parse(dataElement.dataset.situations);
+  const targetSelect = document.getElementById('target_id');
+  const situationSelect = document.getElementById('situation_id');
+  const situationContainer = document.getElementById('situation-container');
+
+  function updateSituationsForTarget(targetId) {
+    if (situationContainer) {
+      situationContainer.style.display = 'none';
+    }
+
+    situationSelect.innerHTML = '<option value="">シチュエーションを選んでください</option>';
+
+    const filtered = allSituations.filter(s => s.target_id == targetId);
+    if (filtered.length > 0) {
+      filtered.forEach(s => {
+        const option = document.createElement('option');
+        option.value = s.id;
+        option.textContent = s.name;
+        situationSelect.appendChild(option);
+      });
+
       if (situationContainer) {
-        situationContainer.style.display = 'none';
-      }
-  
-      situationSelect.innerHTML = '<option value="">シチュエーションを選んでください</option>';
-  
-      const filtered = allSituations.filter(s => s.target_id == targetId);
-      if (filtered.length > 0) {
-        filtered.forEach(s => {
-          const option = document.createElement('option');
-          option.value = s.id;
-          option.textContent = s.name;
-          situationSelect.appendChild(option);
-        });
-  
-        if (situationContainer) {
-          situationContainer.style.display = 'block';
-        }
+        situationContainer.style.display = 'block';
       }
     }
-  
-    targetSelect.addEventListener('change', (e) => {
-      updateSituationsForTarget(e.target.value);
-    });
+  }
+
+  targetSelect.addEventListener('change', (e) => {
+    updateSituationsForTarget(e.target.value);
   });
+});

--- a/app/models/positive_word.rb
+++ b/app/models/positive_word.rb
@@ -1,7 +1,10 @@
 class PositiveWord < ApplicationRecord
+    attr_accessor :target_name, :situation_name
+
     belongs_to :user, optional: true
     belongs_to :situation
     belongs_to :target
+    has_many :word_favorites, dependent: :destroy
 
     validates :situation, presence: true
     validates :target, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,18 @@ class User < ApplicationRecord
 
   validates :username, presence: true
   has_many :positive_words, dependent: :destroy
+  has_many :word_favorites, dependent: :destroy
+  has_many :favorited_words, through: :word_favorites, source: :positive_word
+
+  def bookmark(positive_word)
+    favorited_words << positive_word
+  end
+
+  def unbookmark(positive_word)
+    favorited_words.destroy(positive_word)
+  end
+
+  def bookmark?(positive_word)
+    favorited_words.include?(positive_word)
+  end
 end

--- a/app/models/word_favorite.rb
+++ b/app/models/word_favorite.rb
@@ -1,0 +1,6 @@
+class WordFavorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :positive_word
+
+  validates :user_id, uniqueness: { scope: :positive_word_id }
+end

--- a/app/views/ai_messages/new.html.erb
+++ b/app/views/ai_messages/new.html.erb
@@ -3,20 +3,12 @@
 <div class="bg-gradient-to-br from-teal-100 to-lime-200 min-h-screen py-12 px-4 sm:px-6 lg:px-8">
   <div class="max-w-3xl mx-auto bg-white rounded-2xl shadow-lg overflow-hidden">
     <div class="p-8">
-      <h2 class="text-3xl font-semibold text-red-400 text-center mb-6">
-        ポジティブワードを作ろう！
-      </h2>
+      <h2 class="text-3xl font-semibold text-red-400 text-center mb-6">ポジティブワードを作ろう！</h2>
 
       <div class="text-center mb-8 space-y-3">
-        <p class="text-lg text-gray-600">
-          誰に、どんな気持ちを伝えたいですか？
-        </p>
-        <p class="text-lg text-gray-600">
-          下のフォームに自由に書いてみてくださいね！
-        </p>
-        <p class="text-lg text-gray-600">
-          使い方がわからなければ、まずはサンプルを見てみましょう♪
-        </p>
+        <p class="text-lg text-gray-600">誰に、どんな気持ちを伝えたいですか？</p>
+        <p class="text-lg text-gray-600">下のフォームに自由に書いてみてくださいね！</p>
+        <p class="text-lg text-gray-600">使い方がわからなければ、まずはサンプルを見てみましょう♪</p>
         <%= link_to "サンプルを見る", positive_words_path, class: "inline-block bg-yellow-400 hover:bg-yellow-500 text-white font-semibold py-3 px-8 rounded-full shadow-md" %>
       </div>
 
@@ -26,35 +18,49 @@
         </div>
       <% end %>
 
-      <%= form_with url: ai_messages_generate_path, method: :post, data: { turbo: false, type: "json" }, class: "space-y-6", id: "generate-form" do |f| %>
+      <%= form_with model: @positive_word, url: ai_messages_generate_path, method: :post, local: true, class: "space-y-6", id: "generate-form" do |f| %>
         <div>
           <%= f.label :target, '💌 誰に送りますか？', class: 'block mb-2 text-lg font-medium text-gray-700' %>
-          <%= f.text_field :target, placeholder: "例：友達、家族、自分", class: "w-full p-4 rounded-full border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 focus:ring-pink-300", value: params[:target] %>
+          <%= f.text_field :target, value: @target, placeholder: "例：友達、家族、自分", class: "w-full p-4 rounded-full border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 focus:ring-pink-300" %>
         </div>
 
         <div>
           <%= f.label :situation, '🌈 どんな時？', class: 'block mb-2 text-lg font-medium text-gray-700' %>
-          <%= f.text_field :situation, placeholder: "例：褒めたい時、応援したい時", class: "w-full p-4 rounded-full border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 focus:ring-pink-300", value: params[:situation] %>
+          <%= f.text_field :situation, value:  @situation, placeholder: "例：褒めたい時、応援したい時", class: "w-full p-4 rounded-full border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 focus:ring-pink-300" %>
         </div>
 
         <div>
-          <%= f.submit 'ワードを作る', class: "w-full bg-red-400 hover:bg-red-500 text-white font-semibold py-3 px-8 rounded-full shadow-md focus:outline-none focus:ring-2 focus:ring-pink-300" %>
+          <%= f.submit 'ワードを作る', class: "w-full bg-red-400 hover:bg-red-500 text-white font-semibold py-3 px-8 rounded-full shadow-md focus:outline-none focus:ring-2 focus:ring-pink-300 cursor-pointer" %>
         </div>
       <% end %>
 
-      <% if params[:message].present? %>
-      <div class="mt-6 bg-pink-50 py-8 px-8">
-      <h3 class="text-2xl font-semibold text-red-400 text-center mb-6">
-        ポジティブワード生成結果
-      </h3>
-          <p id="ai-message" class="py-3 px-6 bg-white text-2xl text-gray-800 rounded-full shadow-sm font-semibold leading-relaxed hover:bg-yellow-100 transition-all flex items-center">
-          <span class="mr-3 text-pink-400">🌸</span> <%= params[:message] %>
-          </p>
-          <div class="mt-8 flex justify-center">
-          <%= link_to "もう一度作る", new_ai_message_path, class: "px-6 py-3 bg-red-400  text-white rounded-full hover:bg-red-500" %>
-        </div>
-        </div>
+      <% if params[:word_id].present? && (positive_word = PositiveWord.find_by(id: params[:word_id])) %>
+        <div class="mt-6 bg-pink-50 py-8 px-8">
+          <h3 class="text-2xl font-semibold text-red-400 text-center mb-6">ポジティブワード生成結果</h3>
 
+          <p id="ai-message" class="py-3 px-6 bg-white text-2xl text-gray-800 rounded-full shadow-sm font-semibold leading-relaxed hover:bg-yellow-100 transition-all flex items-center gap-x-3">
+            <span class="text-pink-400">🌸</span>
+            <span class="flex-grow"><%= positive_word.word %></span>
+
+            <% if user_signed_in? %>
+              <span id="bookmark-button-for-word-<%= positive_word.id %>">
+                <% if current_user.bookmark?(positive_word) %>
+                  <%= render 'shared/unbookmark', positive_word: positive_word %>
+                <% else %>
+                  <%= render 'shared/bookmark', positive_word: positive_word %>
+                <% end %>
+              </span>
+            <% end %>
+          </p>
+
+          <div class="mt-8 flex justify-center">
+            <%= link_to "もう一度作る", new_ai_message_path, class: "px-6 py-3 bg-red-400 text-white rounded-full hover:bg-red-500" %>
+          </div>
+        </div>
+      <% elsif params[:word_id].present? %>
+        <div class="mt-6 bg-red-100 text-red-600 p-4 rounded-md text-center">
+          ポジティブワードが見つかりませんでした。
+        </div>
       <% end %>
 
       <div class="mt-6 space-y-3 text-center">
@@ -69,4 +75,4 @@
   </div>
 </div>
 
-<%= javascript_include_tag 'ai_messages', 'data-turbolinks-track': 'reload' %>
+<%= javascript_include_tag 'ai_messages', 'data-turbo-track': 'reload', crossorigin: 'anonymous' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,7 +8,7 @@
     <%= csp_meta_tag %>
 
     <%= yield :head %>
-
+    <%= stylesheet_link_tag "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css", rel: "stylesheet" %>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/shared/_bookmark.html.erb
+++ b/app/views/shared/_bookmark.html.erb
@@ -1,0 +1,5 @@
+<%= link_to word_favorites_path(positive_word_id: positive_word.id),
+            data: { turbo_method: :post },
+            class: "text-2xl" do %>
+  <i class="bi bi-star"></i>
+<% end %>

--- a/app/views/shared/_unbookmark.html.erb
+++ b/app/views/shared/_unbookmark.html.erb
@@ -1,0 +1,7 @@
+<% if (fav = current_user.word_favorites.find_by(positive_word_id: positive_word.id)) %>
+  <%= link_to word_favorite_path(fav),
+              data: { turbo_method: :delete },
+              class: "text-2xl" do %>
+    <i class="bi bi-star-fill"></i>
+  <% end %>
+<% end %>

--- a/app/views/shared/_word_favorites_button.html.erb
+++ b/app/views/shared/_word_favorites_button.html.erb
@@ -1,0 +1,7 @@
+<div id="bookmark-button-for-word-<%= positive_word.id %>">
+  <% if current_user.bookmark?(positive_word) %>
+    <%= render 'shared/unbookmark', positive_word: positive_word %>
+  <% else %>
+    <%= render 'shared/bookmark', positive_word: positive_word %>
+  <% end %>
+</div>

--- a/app/views/word_favorites/create.turbo_stream.erb
+++ b/app/views/word_favorites/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bookmark-button-for-word-#{@positive_word.id}" do %>
+  <%= render 'shared/word_favorites_button', positive_word: @positive_word %>
+<% end %>

--- a/app/views/word_favorites/destroy.turbo_stream.erb
+++ b/app/views/word_favorites/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "bookmark-button-for-word-#{@positive_word.id}" do %>
+  <%= render 'shared/word_favorites_button', positive_word: @positive_word %>
+<% end %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -34,8 +34,8 @@ Rails.application.configure do
   # マイグレーション後にスキーマをダンプしない
   config.active_record.dump_schema_after_migration = false
 
-  config.action_mailer.default_url_options = { host: 'graduation-project-x30c.onrender.com' }
-  
+  config.action_mailer.default_url_options = { host: "graduation-project-x30c.onrender.com" }
+
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -3,3 +3,4 @@
 pin "application"
 pin "situations", to: "situations.js"
 pin "ai_messages", to: "ai_messages.js"
+pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true

--- a/config/initializers/openai.rb
+++ b/config/initializers/openai.rb
@@ -1,6 +1,6 @@
-require 'openai'
+require "openai"
 
 OpenAI.configure do |config|
-  config.access_token = ENV['OPENAI_ACCESS_TOKEN']
+  config.access_token = ENV["OPENAI_ACCESS_TOKEN"]
   config.log_errors = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,29 +2,18 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations"
   }
-  get "top/index"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/*
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
   root "top#index"
-  resources :positive_words, only: [ :index ]
-  post 'ai_messages/generate', to: 'ai_messages#generate', as: :ai_messages_generate
-get 'ai_messages/new', to: 'ai_messages#new', as: :new_ai_message
-  
-  resources :userpages, only: [ :index ]
 
+  resources :userpages, only: [ :index ]
+  resources :positive_words, only: [ :index ]
+
+  post "ai_messages/generate", to: "ai_messages#generate", as: :ai_messages_generate
+  get "ai_messages/new", to: "ai_messages#new", as: :new_ai_message
+
+  resources :word_favorites, only: [ :create, :destroy ]
 
   if Rails.env.development?
-    # letter_opener_web へのアクセスを許可
     mount LetterOpenerWeb::Engine, at: "/letter_opener"
   end
 end

--- a/db/migrate/20250430063745_create_word_favorites.rb
+++ b/db/migrate/20250430063745_create_word_favorites.rb
@@ -1,0 +1,11 @@
+class CreateWordFavorites < ActiveRecord::Migration[8.0]
+  def change
+    create_table :word_favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :positive_word, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :word_favorites, [ :user_id, :positive_word_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_20_080053) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_30_063745) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -54,4 +54,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_20_080053) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  create_table "word_favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "positive_word_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["positive_word_id"], name: "index_word_favorites_on_positive_word_id"
+    t.index ["user_id", "positive_word_id"], name: "index_word_favorites_on_user_id_and_positive_word_id", unique: true
+    t.index ["user_id"], name: "index_word_favorites_on_user_id"
+  end
+
+  add_foreign_key "word_favorites", "positive_words"
+  add_foreign_key "word_favorites", "users"
 end

--- a/spec/factories/word_favorites.rb
+++ b/spec/factories/word_favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :word_favorite do
+    user { nil }
+    positive_word { nil }
+  end
+end

--- a/spec/helpers/word_favorites_helper_spec.rb
+++ b/spec/helpers/word_favorites_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the WordFavoritesHelper. For example:
+#
+# describe WordFavoritesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe WordFavoritesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/word_favorite_spec.rb
+++ b/spec/models/word_favorite_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe WordFavorite, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/word_favorites_spec.rb
+++ b/spec/requests/word_favorites_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe "WordFavorites", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/word_favorites/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/word_favorites/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+end

--- a/spec/views/word_favorites/create.html.tailwindcss_spec.rb
+++ b/spec/views/word_favorites/create.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "word_favorites/create.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/word_favorites/destroy.html.tailwindcss_spec.rb
+++ b/spec/views/word_favorites/destroy.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "word_favorites/destroy.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# 概要
**卒業制作⑨基本的機能の実装(メッセージ関連)**
メッセージのお気に入り登録

# 実装内容
- [x]  word_favoritesモデルの生成
- [x] word_favoritesテーブルを生成するためのマイグレーションファイルの用意
- [x] User・PositiveWordモデルに中間テーブルとのアソシエーションを設定する
- [x] word_favoritesのルーティングの設定
- [x] Userモデルにインスタンスメソッドを定義する
- [x] app/views/以下に下記の必要なビューファイルの用意
- shared
       ├── _bookmark.html.erb
       ├── _unbookmark.html.erb
       └── _word_favorites_button.html.erb
- [x] app/controllers/word_favorites_controller.rbにアクションを定義する
- [x] お気に入り登録を非同期にするために下記のファイルを用意
- word_favorites
        ├── create.turbo_stream.erb
        └── destroy.turbo_stream.erb

# 確認方法
 /ai_messages/newより
対象人物とシチュエーションを入力し、「ワードを作る」をクリックすると、ポジティブワードが生成後
ワードの横の「☆」から「★」に。
「★」から「☆」にリロードせずに登録・解除できるか確認


# その他
- [x] 対象人物とシチュエーションを入力しなくてもワードが生成できたためバリデーションの設定を追加

# ISSUE
**Closes #54  **
**Closes #55  **