### PR TITLE
ユーザーページ：ぺージネーションの設定＆検索機能の拡張

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,3 +78,4 @@ gem "dotenv-rails"       # APIキーの.env管理に
 gem "ruby-openai"        # OpenAIのAPIラッパー
 
 gem 'ransack', '4.3.0'
+gem 'kaminari'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.10.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.4)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -406,6 +418,7 @@ DEPENDENCIES
   faker
   importmap-rails
   jbuilder
+  kaminari
   letter_opener_web (~> 2.0)
   pg (~> 1.1)
   pry

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,2 @@
 @import "tailwindcss";
+

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,2 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
+import "./userpage_tabs"

--- a/app/javascript/userpage_tabs.js
+++ b/app/javascript/userpage_tabs.js
@@ -1,0 +1,25 @@
+document.addEventListener("turbo:load", () => {
+  const buttons = document.querySelectorAll(".tab-button");
+  const contents = document.querySelectorAll("[data-tab-content]");
+
+  if (buttons.length === 0 || contents.length === 0) return;
+
+  buttons.forEach(button => {
+    button.addEventListener("click", () => {
+      const target = button.getAttribute("data-tab");
+
+      // タブコンテンツの表示切り替え
+      contents.forEach(content => {
+        content.classList.add("hidden");
+      });
+
+      const showContent = document.querySelector(`[data-tab-content="${target}"]`);
+      if (showContent) showContent.classList.remove("hidden");
+
+      // URLを書き換えて ?tab=xxx を保持
+      const url = new URL(window.location);
+      url.searchParams.set("tab", target);
+      history.replaceState(null, "", url);
+    });
+  });
+});

--- a/app/javascript/userpage_tabs.js
+++ b/app/javascript/userpage_tabs.js
@@ -4,22 +4,53 @@ document.addEventListener("turbo:load", () => {
 
   if (buttons.length === 0 || contents.length === 0) return;
 
+  // 初期アクティブタブ取得
+  const activeButton = Array.from(buttons).find(btn => btn.getAttribute("aria-selected") === "true");
+  if (activeButton) {
+    setActiveTab(activeButton.getAttribute("data-tab"));
+  }
+
+  // タブクリック時の処理
   buttons.forEach(button => {
     button.addEventListener("click", () => {
       const target = button.getAttribute("data-tab");
+      setActiveTab(target);
 
-      // タブコンテンツの表示切り替え
-      contents.forEach(content => {
-        content.classList.add("hidden");
-      });
-
-      const showContent = document.querySelector(`[data-tab-content="${target}"]`);
-      if (showContent) showContent.classList.remove("hidden");
-
-      // URLを書き換えて ?tab=xxx を保持
+      // URLの更新
       const url = new URL(window.location);
       url.searchParams.set("tab", target);
       history.replaceState(null, "", url);
     });
   });
+
+  function setActiveTab(target) {
+    // コンテンツの切り替え
+    contents.forEach(content => {
+      content.classList.add("hidden");
+    });
+    const showContent = document.querySelector(`[data-tab-content="${target}"]`);
+    if (showContent) showContent.classList.remove("hidden");
+
+    // ボタンの見た目を更新
+    buttons.forEach(btn => {
+      btn.className = "tab-button py-2 px-10 font-semibold transition duration-300 ease-in-out focus:outline-none";
+      const defaultClass = btn.getAttribute("data-default-class");
+      if (defaultClass) {
+        defaultClass.split(" ").forEach(c => btn.classList.add(c));
+      }
+    });
+
+    // アクティブなタブに色付け
+    const activeBtn = document.querySelector(`.tab-button[data-tab="${target}"]`);
+    if (activeBtn) {
+      activeBtn.classList.remove("bg-blue-100", "bg-green-50", "bg-yellow-100", "text-gray-700", "hover:bg-gray-200", "hover:bg-green-200", "hover:bg-yellow-200");
+      if (target === "all") {
+        activeBtn.classList.add("bg-blue-200", "text-blue-600");
+      } else if (target === "custom") {
+        activeBtn.classList.add("bg-green-200", "text-green-700");
+      } else if (target === "favorite") {
+        activeBtn.classList.add("bg-yellow-200", "text-yellow-700");
+      }
+    }
+  }
 });

--- a/app/models/positive_word.rb
+++ b/app/models/positive_word.rb
@@ -10,7 +10,10 @@ class PositiveWord < ApplicationRecord
     validates :target, presence: true, unless: :is_custom?
   
     def self.ransackable_attributes(auth_object = nil)
-      ["created_at", "id", "is_custom", "situation_id", "target_id", "updated_at", "user_id", "word"]
+      ["word"]
     end
-  end
-  
+
+    def self.ransackable_associations(auth_object = nil)
+      %w[situation target]
+    end
+  end 

--- a/app/models/word_favorite.rb
+++ b/app/models/word_favorite.rb
@@ -3,12 +3,4 @@ class WordFavorite < ApplicationRecord
   belongs_to :positive_word
 
   validates :user_id, uniqueness: { scope: :positive_word_id }
-
-  def self.ransackable_associations(auth_object = nil)
-    %w[positive_word]
-  end
-
-  def self.ransackable_attributes(auth_object = nil)
-    %w[id user_id positive_word_id created_at updated_at]
-  end
 end

--- a/app/views/userpages/_custom_words_section.html.erb
+++ b/app/views/userpages/_custom_words_section.html.erb
@@ -1,8 +1,8 @@
-<div class="mt-6 bg-green-50 py-4 px-4 rounded-xl shadow">
+<div class="bg-green-100 py-2 px-4">
   <h3 class="text-center text-2xl sm:text-3xl font-semibold text-green-600 py-4">
     カスタムワード: <span class="text-pink-500"><%= @custom_words.count %></span> 個
   </h3>
-  <ul class="space-y-2 text-lg text-gray-700">
+  <ul class="mb-8 space-y-2 text-lg text-gray-700">
     <% words.each do |word| %>
       <li class="py-3 px-6 bg-white text-2xl text-gray-800 rounded-full shadow-sm font-semibold leading-relaxed hover:bg-yellow-100 transition-all flex items-center justify-between gap-x-3">
         <div class="flex items-center gap-x-3">

--- a/app/views/userpages/_custom_words_section.html.erb
+++ b/app/views/userpages/_custom_words_section.html.erb
@@ -1,0 +1,18 @@
+<div class="mt-6 bg-green-50 py-4 px-4 rounded-xl shadow">
+  <h3 class="text-center text-2xl sm:text-3xl font-semibold text-green-600 py-4">
+    カスタムワード: <span class="text-pink-500"><%= @custom_words.count %></span> 個
+  </h3>
+  <ul class="space-y-2 text-lg text-gray-700">
+    <% words.each do |word| %>
+      <li class="py-3 px-6 bg-white text-2xl text-gray-800 rounded-full shadow-sm font-semibold leading-relaxed hover:bg-yellow-100 transition-all flex items-center justify-between gap-x-3">
+        <div class="flex items-center gap-x-3">
+          <span class="text-green-600">●</span>
+          <%= word.word %>
+        </div>
+        <%= button_to userpage_path(word), method: :delete, form: { data: { turbo: false } }, class: "text-red-600 hover:text-red-800" do %>     
+          <i class="bi bi-trash-fill"></i>
+        <% end %>
+      </li>
+    <% end %>
+  </ul>
+</div>

--- a/app/views/userpages/_favorited_words_section.html.erb
+++ b/app/views/userpages/_favorited_words_section.html.erb
@@ -1,8 +1,8 @@
-<div class="mt-6 bg-yellow-50 py-4 px-4 rounded-xl shadow">
+<div class=" bg-yellow-100 py-4 px-4">
   <h3 class="text-center text-2xl sm:text-3xl font-semibold text-yellow-600 py-4">
     お気に入り登録: <span class="text-pink-500"><%= @favorited_words.count %></span> 個
   </h3>
-  <div class="space-y-2">
+  <div class="space-y-2 mb-8">
     <%= render partial: 'ai_messages/result', collection: words, as: :positive_word,
                 locals: {
                   show_header_and_button: false, favorited_word_ids: @favorited_word_ids

--- a/app/views/userpages/_favorited_words_section.html.erb
+++ b/app/views/userpages/_favorited_words_section.html.erb
@@ -1,0 +1,11 @@
+<div class="mt-6 bg-yellow-50 py-4 px-4 rounded-xl shadow">
+  <h3 class="text-center text-2xl sm:text-3xl font-semibold text-yellow-600 py-4">
+    お気に入り登録: <span class="text-pink-500"><%= @favorited_words.count %></span> 個
+  </h3>
+  <div class="space-y-2">
+    <%= render partial: 'ai_messages/result', collection: words, as: :positive_word,
+                locals: {
+                  show_header_and_button: false, favorited_word_ids: @favorited_word_ids
+                } %>
+  </div>
+</div>

--- a/app/views/userpages/_new.html.erb
+++ b/app/views/userpages/_new.html.erb
@@ -1,12 +1,14 @@
-<%= form_with model: PositiveWord.new, url: userpages_path, local: true do |f| %>
-    <div class="py-3">
-      <%= f.label :word, "自分でポジティブワードを追加する", class: "block mb-2 text-lg font-medium text-gray-700" %>
-      <%= f.text_field :word, placeholder: 'ワードを入力',class: "w-full p-4 rounded-full border border-gray-300 focus:outline-none focus:ring-2 focus:ring-green-700 text-gray-700" %>
-    </div>
-  
-    <%= f.hidden_field :is_custom, value: true %>
-  
-    <div class="text-center">
-      <%= f.submit "追加", class: "bg-yellow-400 hover:bg-yellow-500 text-white py-3 px-8 rounded-full font-semibold" %>
-    </div>
-  <% end %>
+<div class="bg-green-100 py-2 px-2 ">
+ <%= form_with model: PositiveWord.new, url: userpages_path, local: true do |f| %>
+ <h3 class="text-xl font-semibold text-green-600 text-center p-4">自分でポジティブワードを追加する</h3>
+ <div class="mb-4">
+ <%= f.text_field :word, placeholder: 'ワードを入力', class: "w-full p-3 rounded-full border border-gray-300 focus:outline-none focus:ring-2 focus:ring-green-700 text-gray-700" %>
+ </div>
+
+ <%= f.hidden_field :is_custom, value: true %>
+
+ <div class="text-center">
+ <%= f.submit "追加", class: "mb-4 bg-green-500 hover:bg-green-600 text-white py-3 px-6 rounded-full font-semibold" %>
+ </div>
+ <% end %>
+</div>

--- a/app/views/userpages/_search.html.erb
+++ b/app/views/userpages/_search.html.erb
@@ -1,6 +1,6 @@
 <%= search_form_for @q, url: userpages_path, method: :get, html: { class: 'w-full' } do |f| %>
     <div class="flex w-full space-x-2">
-      <%= f.text_field :positive_word_word_cont,
+      <%= f.text_field :word_cont,
           class: 'flex-grow p-2 border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 rounded',
           placeholder: 'ワード検索' %>
       <%= f.submit '検索',

--- a/app/views/userpages/_search.html.erb
+++ b/app/views/userpages/_search.html.erb
@@ -1,5 +1,5 @@
 <%= search_form_for @q, url: userpages_path, method: :get, html: { class: 'w-full' } do |f| %>
-    <div class="flex w-full space-x-2">
+    <div class="flex w-full space-x-2 mb-6">
       <%= f.text_field :word_cont,
           class: 'flex-grow p-2 border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 rounded',
           placeholder: 'ワード検索' %>

--- a/app/views/userpages/index.html.erb
+++ b/app/views/userpages/index.html.erb
@@ -11,50 +11,59 @@
 
   <%= render 'search', q: @q %>
 
-<div class="flex justify-center space-x-4 p-4">
-  <button data-tab="all" class="tab-button bg-yellow-400 hover:bg-yellow-500 text-white font-bold py-2 px-4 rounded-full">すべて</button>
-  <button data-tab="custom" class="tab-button bg-pink-400 hover:bg-pink-500 text-white font-bold py-2 px-4 rounded-full">カスタム</button>
-  <button data-tab="favorite" class="tab-button bg-blue-400 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded-full">お気に入り</button>
-</div>
+<button data-tab="all" class="tab-button py-2 px-10 font-semibold transition duration-300 ease-in-out focus:outline-none"
+        data-default-class="bg-blue-100 text-gray-700 hover:bg-gray-200"
+        aria-selected="<%= @active_tab == 'all' %>">
+  すべて
+</button>
 
-  <div class="mt-6">
-    <%= render 'new' %>
-  </div>
+<button data-tab="custom" class="tab-button py-2 px-10 font-semibold transition duration-300 ease-in-out focus:outline-none"
+        data-default-class="bg-green-50 text-gray-700 hover:bg-green-200"
+        aria-selected="<%= @active_tab == 'custom' %>">
+  カスタム
+</button>
+
+<button data-tab="favorite" class="tab-button py-2 px-10 font-semibold transition duration-300 ease-in-out focus:outline-none"
+        data-default-class="bg-yellow-100 text-gray-700 hover:bg-yellow-200"
+        aria-selected="<%= @active_tab == 'favorite' %>">
+  お気に入り
+</button>
 
   <div data-tab-content="all" class="<%= 'hidden' unless @active_tab == 'all' %>">
-  <% if @custom_words.present? %>
-    <%= render 'custom_words_section', words: @custom_words_page %>
-    <%= paginate @custom_words_page, param_name: :custom_page, params: { tab: 'all' } %>
-  <% end %>
+    <%= render 'new' %>
+    <% if @custom_words.present? %>
+      <%= render 'custom_words_section', words: @custom_words_page %>
+      <%= paginate @custom_words_page, param_name: :custom_page, params: { tab: 'all' } %>
+    <% end %>
 
-  <% if @favorited_words.present? %>
-    <%= render 'favorited_words_section', words: @favorited_words_page %>
-    <%= paginate @favorited_words_page, param_name: :favorited_page, params: { tab: 'all' } %>
-  <% end %>
+    <% if @favorited_words.present? %>
+      <%= render 'favorited_words_section', words: @favorited_words_page %>
+      <%= paginate @favorited_words_page, param_name: :favorited_page, params: { tab: 'all' } %>
+    <% end %>
 
     <% if @custom_words.blank? && @favorited_words.blank? %>
-    <p class="text-center text-lg text-gray-600 py-8">登録されたワードはありません</p>
-  <% end %>
-</div>
+      <p class="text-center text-lg text-gray-600 py-8">登録されたワードはありません</p>
+    <% end %>
+  </div>
 
-<div data-tab-content="custom" class="<%= 'hidden' unless @active_tab == 'custom' %>">
-  <% if @custom_words.present? %>
-    <%= render 'custom_words_section', words: @custom_words_page %>
-    <%= paginate @custom_words_page, param_name: :custom_page, params: { tab: 'custom' } %>
-  <% else %>
-    <p class="text-center text-lg text-gray-600 py-8">カスタムワードはありません</p>
-  <% end %>
-</div>
+  <div data-tab-content="custom" class="<%= 'hidden' unless @active_tab == 'custom' %>">
+    <%= render 'new' %>
+    <% if @custom_words.present? %>
+      <%= render 'custom_words_section', words: @custom_words_page %>
+      <%= paginate @custom_words_page, param_name: :custom_page, params: { tab: 'custom' } %>
+    <% else %>
+      <p class="text-center text-lg text-gray-600 py-8">カスタムワードはありません</p>
+    <% end %>
+  </div>
 
-<div data-tab-content="favorite" class="<%= 'hidden' unless @active_tab == 'favorite' %>">
-  <% if @favorited_words.present? %>
-    <%= render 'favorited_words_section', words: @favorited_words_page %>
-   <%= paginate @favorited_words_page, param_name: :favorited_page, params: { tab: 'favorite' } %>
-  <% else %>
-    <p class="text-center text-lg text-gray-600 py-8">お気に入り登録はありません</p>
-  <% end %>
-</div>
- 
+  <div data-tab-content="favorite" class="<%= 'hidden' unless @active_tab == 'favorite' %>">
+    <% if @favorited_words.present? %>
+      <%= render 'favorited_words_section', words: @favorited_words_page %>
+      <%= paginate @favorited_words_page, param_name: :favorited_page, params: { tab: 'favorite' } %>
+    <% else %>
+      <p class="text-center text-lg text-gray-600 py-8">お気に入り登録はありません</p>
+    <% end %>
+  </div>
 
   <div class="mt-8 space-y-4">
     <%= link_to "トップページに戻る", root_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
@@ -66,4 +75,3 @@
     </div>
   </div>
 </div>
-

--- a/app/views/userpages/index.html.erb
+++ b/app/views/userpages/index.html.erb
@@ -6,48 +6,55 @@
   </h2>
 
   <h3 class="mt-6 text-center text-6xl font-semibold text-gray-700 mb-4">
-  これまでに知ったワードの合計: <span class="text-pink-500"><%= @known_word_count %></span> 個
+    これまでに知ったワードの合計: <span class="text-pink-500"><%= @known_word_count %></span> 個
   </h3>
 
   <%= render 'search', q: @q %>
 
-  <div class="mt-6 bg-green-50 py-4 px-4 rounded-xl shadow">
-  <%= render 'new' %>
+<div class="flex justify-center space-x-4 p-4">
+  <button data-tab="all" class="tab-button bg-yellow-400 hover:bg-yellow-500 text-white font-bold py-2 px-4 rounded-full">すべて</button>
+  <button data-tab="custom" class="tab-button bg-pink-400 hover:bg-pink-500 text-white font-bold py-2 px-4 rounded-full">カスタム</button>
+  <button data-tab="favorite" class="tab-button bg-blue-400 hover:bg-blue-500 text-white font-bold py-2 px-4 rounded-full">お気に入り</button>
+</div>
 
-<% if @custom_words.present? %>
-    <h3 class="text-center text-2xl sm:text-3xl font-semibold text-green-600 py-4">
-     カスタムワード: <span class="text-pink-500"><%= @custom_words.count %></span> 個
-    </h3>
-    <ul class="space-y-2 text-lg text-gray-700">
-    <% @custom_words.each do |word| %>
-      <li class="py-3 px-6 bg-white text-2xl text-gray-800 rounded-full shadow-sm font-semibold leading-relaxed hover:bg-yellow-100 transition-all flex items-center justify-between gap-x-3">
-        <div class="flex items-center gap-x-3">
-          <span class="text-green-600">●</span>
-          <%= word.word %>
-        </div>
-        <%= button_to userpage_path(word), method: :delete, form: { data: { turbo: false } }, class: "text-red-600 hover:text-red-800" do %>
-          <i class="bi bi-trash-fill"></i>
-        <% end %>
-      </li>
-    <% end %>
-  </ul>
-<% end %>
+  <div class="mt-6">
+    <%= render 'new' %>
   </div>
 
-  <% if @favorited_words.present? %>
-    <div class="mt-6 bg-yellow-50 py-4 px-4 rounded-xl shadow">
-      <h3 class="text-center text-2xl sm:text-3xl font-semibold text-yellow-600 py-4">
-        お気に入り登録: <span class="text-pink-500"><%= @favorited_words.count %></span> 個
-      </h3>
-      <div class="space-y-2">
-        <%= render partial: 'ai_messages/result', collection: @favorited_words, as: :positive_word, locals: { show_header_and_button: false, favorited_word_ids: @favorited_word_ids } %>
-      </div>
-    </div>
-  <% else %>
-    <p class="text-center text-lg text-gray-600 py-8">
-      お気に入り登録はありません
-    </p>
+  <div data-tab-content="all" class="<%= 'hidden' unless @active_tab == 'all' %>">
+  <% if @custom_words.present? %>
+    <%= render 'custom_words_section', words: @custom_words_page %>
+    <%= paginate @custom_words_page, param_name: :custom_page, params: { tab: 'all' } %>
   <% end %>
+
+  <% if @favorited_words.present? %>
+    <%= render 'favorited_words_section', words: @favorited_words_page %>
+    <%= paginate @favorited_words_page, param_name: :favorited_page, params: { tab: 'all' } %>
+  <% end %>
+
+    <% if @custom_words.blank? && @favorited_words.blank? %>
+    <p class="text-center text-lg text-gray-600 py-8">登録されたワードはありません</p>
+  <% end %>
+</div>
+
+<div data-tab-content="custom" class="<%= 'hidden' unless @active_tab == 'custom' %>">
+  <% if @custom_words.present? %>
+    <%= render 'custom_words_section', words: @custom_words_page %>
+    <%= paginate @custom_words_page, param_name: :custom_page, params: { tab: 'custom' } %>
+  <% else %>
+    <p class="text-center text-lg text-gray-600 py-8">カスタムワードはありません</p>
+  <% end %>
+</div>
+
+<div data-tab-content="favorite" class="<%= 'hidden' unless @active_tab == 'favorite' %>">
+  <% if @favorited_words.present? %>
+    <%= render 'favorited_words_section', words: @favorited_words_page %>
+   <%= paginate @favorited_words_page, param_name: :favorited_page, params: { tab: 'favorite' } %>
+  <% else %>
+    <p class="text-center text-lg text-gray-600 py-8">お気に入り登録はありません</p>
+  <% end %>
+</div>
+ 
 
   <div class="mt-8 space-y-4">
     <%= link_to "トップページに戻る", root_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
@@ -59,3 +66,4 @@
     </div>
   </div>
 </div>
+

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -4,3 +4,4 @@ pin "application"
 pin "situations", to: "situations.js"
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 
+pin "userpage_tabs", to: "userpage_tabs.js"

--- a/vendor/javascript/tabs.js
+++ b/vendor/javascript/tabs.js
@@ -1,0 +1,4 @@
+// tabs@0.2.0 downloaded from https://ga.jspm.io/npm:tabs@0.2.0/index.js
+
+var a="undefined"!==typeof globalThis?globalThis:"undefined"!==typeof self?self:global;var e={};!function(s,t){e?e=t():(this||a)[s]=t()}("tabs",(function(){return function tabs(a){var tabs=a.querySelectorAll(".tab");var e=a.querySelectorAll(".tab-pane");each(tabs,(function(a,s){s.addEventListener("click",(function(s){activate(tabs,a);activate(e,a)}))}));function activate(a,e){each(a,(function(a,s){a!=e?removeClass(s,"active"):addClass(s,"active")}))}};function each(a,e){for(var s=a.length-1;s>=0;s--)e(s,a[s])}function hasClass(a,e){return a.className.match(new RegExp("(\\s|^)"+e+"(\\s|$)"))}function addClass(a,e){hasClass(a,e)||(a.className+=" "+e)}function removeClass(a,e){if(hasClass(a,e)){var s=new RegExp("(\\s|^)"+e+"(\\s|$)");a.className=a.className.replace(s,"")}}}));var s=e;export default s;
+


### PR DESCRIPTION
# 概要
**卒業制作⑨基本的機能の実装(メッセージ関連)**
ユーザーページ：ぺージネーションの設定＆検索機能の拡張

# 実装内容
- [x]  /userpagesの検索機能にカスタムワードも検索できるように拡張
- [x] gem Kaminariを導入しカスタムワード、お気に入り登録のぺージを10個以上から2ページ目にいくように設定
- [x] ワードごとにタブを分けるUIの調整 

# 確認方法
 /userpageより
- [x] すべて・カスタム・お気に入りのタブよりそれぞれ対応したワードのみ表示されるか
- [x] 10個以上ワードがある場合2ページにいくか、それぞれのワードの下にぺージネーションの表示があるか
- [x]  検索はお気に入り登録したワード、カスタムワードできるか
- 検索をかけた場合カスタムワードなら、お気に入りのタブの際ない旨の表示になるか
- お気に入り登録したワードの場合はカスタムのタブの際ない旨の表示になるか
- どちらも該当しない場合はすべてのタブでない旨の表示になるか


# ISSUE
**Closes #63  **