### PR TITLE
投稿のお気に入り登録

### DIFF
--- a/app/controllers/post_favorites_controller.rb
+++ b/app/controllers/post_favorites_controller.rb
@@ -1,0 +1,14 @@
+class PostFavoritesController < ApplicationController
+    before_action :authenticate_user!
+  
+    def create
+      @post = Post.find(params[:post_id])
+      current_user.post_bookmark(@post)
+    end
+  
+    def destroy
+      @post = current_user.post_favorites.find(params[:id]).post
+      current_user.unpost_bookmark(@post)
+    end
+  end
+  

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -3,7 +3,13 @@ class PostsController < ApplicationController
 
   def index
     @q = Post.ransack(params[:q])
-    @posts = @q.result(distinct: true).includes(:user).order("created_at desc")
+    @posts = @q.result(distinct: true).includes(:user).order("created_at desc").page(params[:page]).per(10)
+  end
+
+  def post_favorites
+    @q = current_user.favorite_posts.ransack(params[:q])
+    @post_favorites = @q.result(distinct: true).includes(:user).order("created_at desc").page(params[:page]).per(10)
+    @post_favorites_count = current_user.favorite_posts.count
   end
 
   def new

--- a/app/helpers/post_favorites_helper.rb
+++ b/app/helpers/post_favorites_helper.rb
@@ -1,0 +1,2 @@
+module PostFavoritesHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,6 +1,7 @@
 class Post < ApplicationRecord
   belongs_to :user
   belongs_to :positive_word, optional: true
+  has_many :post_favorites, dependent: :destroy
 
   validates :post_word, presence: true, length: { maximum: 100 }
 

--- a/app/models/post_favorite.rb
+++ b/app/models/post_favorite.rb
@@ -1,0 +1,6 @@
+class PostFavorite < ApplicationRecord
+  belongs_to :user
+  belongs_to :post
+
+  validates :user_id, uniqueness: { scope: :post_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   has_many :positive_words, dependent: :destroy
   has_many :word_favorites, dependent: :destroy
   has_many :favorited_words, through: :word_favorites, source: :positive_word
+  has_many :post_favorites, dependent: :destroy
+  has_many :favorite_posts,  through: :post_favorites,  source: :post
 
   has_many :posts, dependent: :destroy
 
@@ -23,6 +25,18 @@ class User < ApplicationRecord
 
   def bookmark?(positive_word)
     favorited_words.include?(positive_word)
+  end
+
+  def post_bookmark(post)
+    favorite_posts << post
+  end
+  
+  def unpost_bookmark(post)
+    favorite_posts.destroy(post)
+  end
+  
+  def post_bookmarked?(post)
+    favorite_posts.include?(post)
   end
 
   def own?(object)

--- a/app/views/post_favorites/create.turbo_stream.erb
+++ b/app/views/post_favorites/create.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "post-favorite-button-#{@post.id}" do %>
+  <%= render 'shared/post_favorites_button', post: @post %>
+<% end %>

--- a/app/views/post_favorites/destroy.turbo_stream.erb
+++ b/app/views/post_favorites/destroy.turbo_stream.erb
@@ -1,0 +1,3 @@
+<%= turbo_stream.replace "post-favorite-button-#{@post.id}" do %>
+  <%= render 'shared/post_favorites_button', post: @post %>
+<% end %>

--- a/app/views/posts/_card.html.erb
+++ b/app/views/posts/_card.html.erb
@@ -1,0 +1,26 @@
+<div class="bg-white rounded-xl shadow-md overflow-hidden border border-gray-200 mb-4">
+  <div class="p-6">
+    <h4 class="text-xl font-semibold text-red-500 mb-3 rounded-full bg-red-100 px-4 py-2 inline-block">
+      <%= link_to post.post_word, post_path(post), class: 'hover:text-red-700' %>
+    </h4>
+    <p class="text-gray-700 leading-relaxed mb-4 rounded-lg bg-yellow-50 p-3">
+      <%= post.caption %>
+    </p>
+    <div class="flex items-center justify-between text-sm text-gray-600">
+      <span>投稿者: <%= link_to post.user.username, class: 'font-medium text-blue-500 hover:text-blue-700' %></span>
+      <span><%= l post.created_at, format: :short %></span>
+    </div>
+  </div>
+  <div class="bg-gray-50 px-6 py-3 flex justify-end items-center space-x-3 border-t border-gray-200 rounded-b-xl">
+    <% if current_user.own?(post) %>
+      <%= link_to edit_post_path(post), id: "button-edit-#{post.id}", class: 'text-blue-500 hover:text-blue-700' do %>
+        <i class="bi bi-pencil-fill"></i>
+      <% end %>
+      <%= link_to post_path(post), id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '削除しました'}, class: 'text-red-500 hover:text-red-700' do %>
+        <i class="bi bi-trash-fill"></i>
+      <% end %>
+    <% else %>
+      <%= render 'shared/post_favorites_button', post: post %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/posts/_search.html.erb
+++ b/app/views/posts/_search.html.erb
@@ -1,9 +1,9 @@
-<%= search_form_for @q, url: posts_path, method: :get, html: { class: 'w-full' } do |f| %>
-    <div class="flex w-full space-x-2 mb-6">
-      <%= f.text_field :post_word_or_caption_cont,
-          class: 'flex-grow p-2 border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 rounded',
-          placeholder: 'ワード検索' %>
-      <%= f.submit '検索',
-          class: 'whitespace-nowrap text-white bg-indigo-500 hover:bg-indigo-600 py-2 px-4 rounded shadow-md' %>
-    </div>
-  <% end %>
+<%= search_form_for q, url: url, method: :get, html: { class: 'w-full' } do |f| %>
+  <div class="flex w-full space-x-2 mb-6">
+    <%= f.text_field :post_word_or_caption_cont,
+      class: 'flex-grow p-4 border border-gray-300 text-gray-700 focus:outline-none focus:ring-2 focus:ring-red-300 rounded-full',
+      placeholder: 'ポジティブワードまたはキャプションで検索' %>
+    <%= f.submit '検索',
+      class: 'whitespace-nowrap text-white bg-red-400 hover:bg-red-500 py-3 px-6 rounded-full shadow-md cursor-pointer' %>
+  </div>
+<% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,35 +1,41 @@
-<%= content_for :title, "投稿ページ" %>
+<%= content_for :title, "ポジティブ掲示板" %>
 
-<div class="max-w-3xl mx-auto bg-white p-6 rounded-lg shadow-lg">
-  <h2 class="text-center text-3xl font-semibold text-yellow-600 mb-8">
-    みんなのポジほめワード
-  </h2>
-  
-  <%= render 'search' %>
-  
-  <%= link_to "+ 新規投稿", new_post_path, class: 'block text-right text-3xl font-bold text-blue-500 hover:text-blue-700 hover:underline' %>
+<div class="bg-gradient-to-br from-teal-100 to-lime-200 min-h-screen py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-3xl mx-auto bg-white rounded-2xl shadow-lg overflow-hidden">
+    <div class="bg-yellow-100 py-8 px-6 rounded-t-2xl border-b border-yellow-200">
+      <h1 class="text-3xl font-bold text-yellow-600 text-center mb-4">
+        <i class="fas fa-sun text-yellow-400 mr-2"></i> ポジティブ掲示板
+      </h1>
+      <p class="text-lg text-gray-700 text-center">
+        日々の素敵な発見や、心を明るくする言葉をシェアしましょう。
+      </p>
+    </div>
 
-  <% if @posts.present? %>
-    <% @posts.each do |post| %>
-      <div id="post-id-<%= post.id %>">
-        <h4 class="text-lg font-semibold text-gray-700">
-          <%= link_to post.post_word, post_path(post) %>
-        </h4>
-         <p><%= post.caption %></p>
-         <%= post.user.username %>
-         <%= l post.created_at, format: :short %>
+    <div class="p-6">
+      <%= render 'search', q: @q, url: posts_path %>
+
+      <div class="mt-6 flex justify-center space-x-4">
+        <%= link_to "お気に入り", favorites_posts_path, class: 'inline-flex items-center text-lg font-semibold text-blue-600 bg-blue-100 hover:bg-blue-200 px-6 py-3 rounded-full shadow-sm' %>
+        <%= link_to "+ 新規投稿", new_post_path, class: 'inline-flex items-center text-lg font-bold text-white bg-gradient-to-br from-green-400 to-green-500 hover:from-green-500 hover:to-green-600 px-6 py-3 rounded-full shadow-md' %>
       </div>
-    <% end %>
-    <% else %>
-     <p>投稿はありません</p>
-    <% end %>
 
-  <div class="mt-8 space-y-4">
-    <%= link_to "トップページに戻る", root_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
-    <%= link_to "ポジティブワードを作ろう", new_ai_message_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
-    <%= link_to "メッセージを振り返る(ユーザーページ)", userpages_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-700 hover:underline' %>
-    <div class="flex justify-center space-x-4 mt-6">
-      <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'text-sm font-medium text-white bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full shadow-md' %>
+      <div class="mt-8">
+        <% if @posts.present? %>
+          <ul class="space-y-4">
+            <%= render partial: 'posts/card', collection: @posts, as: :post %>
+          </ul>
+          <%= paginate @posts, param_name: :page %>
+        <% else %>
+          <p class="text-gray-600 italic text-center">まだ投稿はありません。</p>
+        <% end %>
+      </div>
+
+      <div class="mt-8 space-y-4">
+      <%= link_to "トップページに戻る", root_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
+      <%= link_to "ポジティブワードを作ろう", new_ai_message_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
+      <%= link_to "メッセージを振り返る(ユーザーページ)", userpages_path, class: 'block text-center text-lg text-blue-500 font-semibold hover:text-blue-700 hover:underline' %>
+      <div class="flex justify-center space-x-4 mt-6">
+        <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'text-sm font-medium text-white bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full shadow-md' %>
+      </div>
     </div>
   </div>
-</div>

--- a/app/views/posts/post_favorites.html.erb
+++ b/app/views/posts/post_favorites.html.erb
@@ -1,0 +1,27 @@
+<%= content_for :title, "お気に入り登録ページ" %> 
+
+<div class="max-w-3xl mx-auto bg-white p-6 rounded-lg shadow-lg">
+  <h2 class="text-center text-3xl font-semibold text-yellow-600 mb-8">
+    お気に入り登録ワード一覧：<span class="text-pink-500"><%= @post_favorites_count %></span> 個
+  </h2>
+  
+  <%= render 'search', q: @q, url: favorites_posts_path %>
+  
+  <% if @post_favorites.present? %>
+    <%= render partial: 'posts/card', collection: @post_favorites, as: :post %>
+    <%= paginate @post_favorites %>
+    <% else %>
+      <p class="text-center text-lg text-gray-600 py-8">お気に入り登録はありません</p>
+    <% end %>
+
+
+  <div class="mt-8 space-y-4">
+    <%= link_to "投稿一覧に戻る", posts_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
+    <%= link_to "トップページに戻る", root_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
+    <%= link_to "ポジティブワードを作ろう", new_ai_message_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
+    <%= link_to "メッセージを振り返る(ユーザーページ)", userpages_path, class: 'block text-center text-lg text-blue-500 font-semibold hover:text-blue-700 hover:underline' %>
+    <div class="flex justify-center space-x-4 mt-6">
+      <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'text-sm font-medium text-white bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full shadow-md' %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,36 +1,47 @@
-<% content_for(:post_word, @post.post_word) %>
-<div class="max-w-3xl mx-auto bg-white p-6 rounded-lg shadow-lg">
-  <h2 class="text-center text-3xl font-semibold text-yellow-600 mb-8">
-    投稿詳細
-  </h2>
+<%= content_for(:post_word, @post.post_word) %>
 
-  <h3 class="text-3xl font-semibold text-yellow-600 mb-4">
-   <%= @post.post_word %>
-   </h3>
-  <p><%= simple_format(@post.caption) %></p>
-  <ul>
-  <li ><%= "#{@post.user.username}" %></li>
-  <li ><%= l @post.created_at, format: :long %></li>
-</ul>
- 
-<% if current_user.own?(@post) %>
-  <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}" do %>
-
-   <i class="bi bi-pencil-fill"></i>
-       <% end %>
-  <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: '削除しました'} do %>
-    <i class="bi bi-trash-fill"></i>
-   <% end %>
-    <% end %>
-
-  <div class="mt-8 space-y-4">
-  <%= link_to "投稿一覧に戻る", posts_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
-  <%= link_to "トップページに戻る", root_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
-  <%= link_to "ポジティブワードを作ろう", new_ai_message_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
-  <%= link_to "メッセージを振り返る(ユーザーページ)", userpages_path, class: 'text-lg text-blue-500 font-semibold hover:text-blue-700 hover:underline' %>
-
-  <div class="flex justify-center space-x-4 mt-6">
-    <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'text-sm font-medium text-white bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full shadow-md' %>
+<div class="max-w-3xl mx-auto bg-white rounded-2xl shadow-lg overflow-hidden">
+  <div class="bg-yellow-100 py-8 px-6 rounded-t-2xl border-b border-yellow-200">
+    <h2 class="text-center text-3xl font-bold text-yellow-600">
+      <i class="fas fa-sun text-yellow-400 mr-2"></i> 投稿詳細
+    </h2>
   </div>
-</div>
+
+  <div class="p-6">
+    <div class="bg-white rounded-xl shadow-md border border-gray-200">
+      <div class="p-6">
+        <h3 class="text-3xl font-semibold text-red-500 mb-4 rounded-full bg-red-100 px-6 py-3 inline-block">
+          <%= @post.post_word %>
+        </h3>
+
+          <%= simple_format(@post.caption) %>
+
+        <div class="flex items-center justify-between text-sm text-gray-600 mb-3">
+          <span>投稿者: <%= link_to @post.user.username, class: 'font-medium text-blue-500 hover:text-blue-700' %></span>
+          <span><%= l @post.created_at, format: :long %></span>
+        </div>
+      </div>
+      <div class="bg-gray-50 px-6 py-3 flex justify-end items-center space-x-3 border-t border-gray-200 rounded-b-xl">
+        <% if current_user.own?(@post) %>
+          <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}", class: 'text-blue-500 hover:text-blue-700' do %>
+            <i class="bi bi-pencil-fill"></i>
+          <% end %>
+          <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: '削除しました'}, class: 'text-red-500 hover:text-red-700' do %>
+            <i class="bi bi-trash-fill"></i>
+          <% end %>
+        <% else %>
+          <%= render 'shared/post_favorites_button', post: @post %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="mt-8 space-y-4">
+    <%= link_to "投稿一覧に戻る", posts_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
+    <%= link_to "トップページに戻る", root_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
+    <%= link_to "ポジティブワードを作ろう", new_ai_message_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
+    <%= link_to "メッセージを振り返る(ユーザーページ)", userpages_path, class: 'block text-center text-lg text-blue-500 font-semibold hover:text-blue-700 hover:underline' %>
+    <div class="flex justify-center space-x-4 mt-6">
+      <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'text-sm font-medium text-white bg-red-500 hover:bg-red-600 px-6 py-3 rounded-full shadow-md' %>
+    </div>
+  </div>
 </div>

--- a/app/views/shared/_post_bookmark.html.erb
+++ b/app/views/shared/_post_bookmark.html.erb
@@ -1,0 +1,5 @@
+<%= link_to post_favorites_path(post_id: post.id),
+            data: { turbo_method: :post },
+            class: "text-2xl" do %>
+  <i class="bi bi-star"></i>
+<% end %>

--- a/app/views/shared/_post_favorites_button.html.erb
+++ b/app/views/shared/_post_favorites_button.html.erb
@@ -1,0 +1,7 @@
+<div id="post-favorite-button-<%= post.id %>">
+  <% if current_user.post_bookmarked?(post) %>
+    <%= render 'shared/unpost_bookmark', post: post %>
+  <% else %>
+    <%= render 'shared/post_bookmark', post: post %>
+  <% end %>
+</div>

--- a/app/views/shared/_unpost_bookmark.html.erb
+++ b/app/views/shared/_unpost_bookmark.html.erb
@@ -1,0 +1,7 @@
+<% if (fav = current_user.post_favorites.find_by(post_id: post.id)) %>
+  <%= link_to post_favorite_path(fav),
+              data: { turbo_method: :delete },
+              class: "text-2xl" do %>
+    <i class="bi bi-star-fill text-yellow-500 hover:text-yellow-600"></i>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,12 @@ Rails.application.routes.draw do
 
   resources :word_favorites, only: %i[create destroy]
 
-  resources :posts, only: %i[ index new create show edit update destroy ]
+  resources :posts do
+    collection do
+      get :post_favorites, as: :favorites
+    end
+  end
+  resources :post_favorites, only: %i[create destroy]
 
   if Rails.env.development?
     mount LetterOpenerWeb::Engine, at: "/letter_opener"

--- a/db/migrate/20250509063750_create_post_favorites.rb
+++ b/db/migrate/20250509063750_create_post_favorites.rb
@@ -1,0 +1,11 @@
+class CreatePostFavorites < ActiveRecord::Migration[8.0]
+  def change
+    create_table :post_favorites do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :post_favorites, [ :user_id, :post_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_07_070736) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_09_063750) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -23,6 +23,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_07_070736) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "source_type", default: 1
+  end
+
+  create_table "post_favorites", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_post_favorites_on_post_id"
+    t.index ["user_id", "post_id"], name: "index_post_favorites_on_user_id_and_post_id", unique: true
+    t.index ["user_id"], name: "index_post_favorites_on_user_id"
   end
 
   create_table "posts", force: :cascade do |t|
@@ -77,6 +87,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_07_070736) do
     t.index ["user_id"], name: "index_word_favorites_on_user_id"
   end
 
+  add_foreign_key "post_favorites", "posts"
+  add_foreign_key "post_favorites", "users"
   add_foreign_key "posts", "positive_words"
   add_foreign_key "posts", "users"
   add_foreign_key "word_favorites", "positive_words"

--- a/spec/factories/post_favorites.rb
+++ b/spec/factories/post_favorites.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post_favorite do
+    user { nil }
+    post { nil }
+  end
+end

--- a/spec/helpers/post_favorites_helper_spec.rb
+++ b/spec/helpers/post_favorites_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the PostFavoritesHelper. For example:
+#
+# describe PostFavoritesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe PostFavoritesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/post_favorite_spec.rb
+++ b/spec/models/post_favorite_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe PostFavorite, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/post_favorites_spec.rb
+++ b/spec/requests/post_favorites_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "PostFavorites", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
# 概要
**卒業制作⑩投稿機能**
投稿のお気に入り登録

# 実装内容
- [x] お気に入り登録をするためのモデルを生成
- app/models/post_favorite.rb
- [x] UserとPostの中間テーブルを生成
- db/migrate/20250509063750_create_post_favorites.rb
- [x]  UserモデルとPostに中間テーブルとのリレーションを設定
- [x] ルーティング設定
- [x] お気に入り登録のコントローラーを生成
- app/controllers/post_favorites_controller.rb
- [x] 投稿用のお気に入りページの作成 
- app/views/posts/post_favorites.html.erb
- [x] お気に入り関連の部分テンプレートを用意
- shared/_post_bookmark.html.erb
- shared/_post_favorites_button.html.erb
- shared/_unpost_bookmark.html.erb

- post_favorites/create.turbo_stream.erb
- post_favorites/destroy.turbo_stream.erb

- [x] お気に入り登録の検索＆ページネーションの設定

# 確認方法
/postsより
- [x] 投稿一覧より他のユーザーが投稿したワードをお気に入り登録・解除できる

/posts/post_favoritesに表示される
- [x] お気に入り登録したワードが検索できる
- [x] お気に入り登録が10件以上なら次のページに行く 


# ISSUE
**Closes #67  **