### PR TITLE
利用規約＆プライバシーポリシー

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,3 +79,4 @@ gem "ruby-openai"        # OpenAIのAPIラッパー
 
 gem "ransack", "4.3.0"
 gem "kaminari"
+gem 'high_voltage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
       net-http (>= 0.5.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    high_voltage (4.0.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.1.0)
@@ -416,6 +417,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faker
+  high_voltage
   importmap-rails
   jbuilder
   kaminari

--- a/app/javascript/userpage_tabs.js
+++ b/app/javascript/userpage_tabs.js
@@ -43,7 +43,7 @@ document.addEventListener("turbo:load", () => {
     // アクティブなタブに色付け
     const activeBtn = document.querySelector(`.tab-button[data-tab="${target}"]`);
     if (activeBtn) {
-      activeBtn.classList.remove("bg-blue-100", "bg-yellow-50", "bg-pink-100", "text-gray-700", "hover:bg-gray-200", "hover:bg-green-200", "hover:bg-pink-200");
+      activeBtn.classList.remove("bg-blue-100", "bg-yellow-50", "bg-pink-100", "text-gray-700", "hover:bg-gray-200", "hover:bg-yellow-200", "hover:bg-pink-200");
       if (target === "all") {
         activeBtn.classList.add("bg-blue-200", "text-blue-600");
       } else if (target === "custom") {

--- a/app/views/pages/policy.html.erb
+++ b/app/views/pages/policy.html.erb
@@ -1,0 +1,99 @@
+<div class="max-w-3xl mx-auto px-4 py-8 text-xl font-medium text-gray-800 leading-relaxed">
+  <h1 class="text-5xl font-bold mb-8 border-b pb-4">プライバシーポリシー</h1>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">お客様から取得する情報</h2>
+    <p class="mb-4">当サービスは、お客様から以下の情報を取得します。</p>
+    <ul class="list-disc list-inside space-y-2">
+      <li>氏名（ニックネームやペンネームを含む）</li>
+      <li>メールアドレス</li>
+      <li>写真や動画</li>
+      <li>外部サービスでお客様が利用するIDおよび、外部サービスのプライバシー設定によりお客様が開示を認めた情報</li>
+      <li>Cookieその他の類似技術により取得される識別情報（IPアドレス、閲覧日時、ページ遷移履歴等）</li>
+      <li>OSが生成するID、端末の種類、端末識別子など、お客様が利用するOSや端末に関する情報</li>
+      <li>当社ウェブサイトにおける滞在時間、入力履歴、購買履歴等の行動履歴</li>
+      <li>当社アプリの起動時間、入力履歴等の利用履歴</li>
+      <li>お客様が当社サービス内で作成したコンテンツ（非公開タスク、メモ等を含む）</li>
+    </ul>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">お客様の情報を利用する目的</h2>
+    <ul class="list-disc list-inside space-y-2">
+      <li>当サービス登録手続の受付、本人確認および認証処理のため</li>
+      <li>当サービスにおけるお客様の利用履歴の管理のため</li>
+      <li>当サービスの利便性向上や機能改善に役立てるため</li>
+      <li>当サービスに関するご案内のため</li>
+      <li>お客様からのお問い合わせへの対応のため</li>
+      <li>当サービスの規約や法令に違反する行為に対する対応のため</li>
+      <li>当サービスに関する重要なお知らせや契約上必要な連絡を行うため</li>
+      <li>当サービス規約の変更などを通知するため</li>
+      <li>その他、当サービスの提供、維持、保護および改善のため</li>
+    </ul>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">安全管理のために講じた措置</h2>
+    <p>
+      当サービスが、お客様から取得した情報に関して安全管理のために講じた措置につきましては、
+      末尾記載のお問い合わせ先にご連絡いただきましたら、法令の定めに従い個別にご回答させていただきます。
+    </p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第三者提供</h2>
+    <p class="mb-2">
+      当サービスは、お客様から取得する情報のうち、個人データ（個人情報保護法第16条第3項）に該当するものについては、
+      あらかじめお客様の同意を得ずに第三者（日本国外の者を含みます。）に提供しません。但し、次の場合は除きます。
+    </p>
+    <ul class="list-disc list-inside space-y-2">
+      <li>個人データの取扱いを外部に委託する場合</li>
+      <li>当サービスが買収された場合</li>
+      <li>事業パートナーとの共同利用（共同利用の内容は別途公表します）</li>
+      <li>その他、法律によって合法的に第三者提供が許されている場合</li>
+    </ul>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">アクセス解析ツールの利用</h2>
+    <p class="mb-2">
+      当サービスは、お客様のアクセス解析のために「Googleアナリティクス」を利用しています。
+      Googleアナリティクスは、トラフィックデータの収集のためにCookieを使用しています。
+      トラフィックデータは匿名で収集されており、個人を特定するものではありません。
+    </p>
+    <p class="mb-2">
+      Cookieを無効にすれば、これらの情報の収集を拒否することができます。詳しくは、お使いのブラウザの設定をご確認ください。
+    </p>
+    <p>
+      Googleアナリティクスの詳細については、以下をご参照ください：<br>
+      <a href="https://marketingplatform.google.com/about/analytics/terms/jp/" class="text-blue-600 underline" target="_blank" rel="noopener noreferrer">
+        https://marketingplatform.google.com/about/analytics/terms/jp/
+      </a>
+    </p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">プライバシーポリシーの変更</h2>
+    <p>
+      当サービスは、必要に応じて本プライバシーポリシーの内容を変更することがあります。
+      その場合、変更後のプライバシーポリシーの施行時期と内容を、当社ウェブサイト等を通じて適切に通知または公表します。
+    </p>
+  </section>
+
+  <section>
+    <h2 class="text-3xl font-bold mb-4">お問い合わせ</h2>
+    <p class="mb-2">
+      お客様の情報の開示、情報の訂正、利用停止、削除をご希望の場合は、お問い合わせフォームよりご連絡ください。
+    </p>
+    <p>
+      ご本人確認のため、運転免許証等の提示をお願いする場合があります。
+      なお、開示請求については、開示の有無にかかわらず、1件あたり1,000円（税込）の事務手数料を申し受けます。
+    </p>
+  </section>
+
+  <section>
+    <p class="mb-2">
+     (2025年5月13日制定)
+    </p>
+  </section>
+</div>

--- a/app/views/pages/term_of_service.html.erb
+++ b/app/views/pages/term_of_service.html.erb
@@ -1,0 +1,106 @@
+<div class="max-w-3xl mx-auto px-4 py-8 text-xl font-medium text-gray-800 leading-relaxed">
+  <h1 class="text-5xl font-bold mb-8 border-b pb-4">利用規約</h1>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第1条（本規約への同意）</h2>
+    <p>ユーザーは、本サービスを利用することにより、本規約に同意したものとみなされます。規約に同意いただけない場合は、本サービスをご利用いただけません。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第2条（利用登録）</h2>
+    <p>本サービスの利用を希望する場合は、本規約に同意のうえ、当社が定める方法により登録を行ってください。</p>
+    <p class="mt-4">登録申請者が以下のいずれかに該当する場合、当社は登録を拒否することがあります。</p>
+    <ul class="list-disc list-inside space-y-2 mt-2">
+      <li>虚偽の情報を提供した場合</li>
+      <li>本規約に違反したことがある者</li>
+      <li>その他、当社が不適切と判断した場合</li>
+    </ul>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第3条（未成年の利用）</h2>
+    <p>未成年のユーザーは、保護者等の法定代理人の同意を得たうえでご利用ください。成年に達した後も未成年時の利用は追認されたものとみなします。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第4条（ログイン情報の管理）</h2>
+    <p>ログイン情報はユーザーが自己の責任において管理するものとし、第三者への譲渡や貸与は禁止します。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第5条（コンテンツの利用）</h2>
+    <p>当社が提供する文章、画像、音声、動画、プログラム等のコンテンツは、本サービス内での私的使用に限り、非独占的に使用を許可します。ユーザーは本サービスの提供が終了した場合に、コンテンツの利用権を失うことをあらかじめ承諾するものとします。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第6条（ユーザー投稿）</h2>
+    <p>ユーザーは、自己の投稿が他者の権利を侵害しないことを保証しなければなりません。</p>
+    <p class="mt-2">投稿に関する著作権はユーザーに帰属しますが、当社は、サービス運営・改善・宣伝のため、無償・無期限・地域無制限で投稿内容を利用できるものとし、著作者人格権は行使しないものとします。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第7条（禁止事項）</h2>
+    <p>ユーザーは、以下のいずれかの行為を行ってはなりません。</p>
+    <ul class="list-disc list-inside space-y-2 mt-2">
+      <li>法令違反、犯罪行為</li>
+      <li>他者の知的財産権、プライバシー、名誉権の侵害</li>
+      <li>本サービスの妨害、改ざん、不正アクセス</li>
+      <li>不適切な投稿（暴力的・わいせつ・差別・誹謗中傷など）</li>
+      <li>商業的利用、広告目的の利用</li>
+      <li>反社会的勢力との関係・支援</li>
+    </ul>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第8条（利用制限および登録抹消）</h2>
+    <p>当社は、以下に該当する場合、ユーザーの利用を制限し、または登録を抹消できるものとします。</p>
+    <ul class="list-disc list-inside space-y-2 mt-2">
+      <li>本規約違反</li>
+      <li>登録情報の虚偽</li>
+      <li>金銭債務の不履行</li>
+      <li>長期間利用がない場合</li>
+      <li>当社が不適切と判断した場合</li>
+    </ul>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第9条（サービス提供の中断・停止）</h2>
+    <p>当社は、以下のいずれかの事由に該当する場合、ユーザーへの通知なくサービスの全部または一部の提供を中断・停止できるものとします。</p>
+    <ul class="list-disc list-inside space-y-2 mt-2">
+      <li>システムの保守・更新</li>
+      <li>天災、通信障害、システム障害などの不可抗力</li>
+      <li>当社が提供困難と判断した場合</li>
+    </ul>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第10条（退会）</h2>
+    <p>ユーザーは、当社所定の手続きにより、いつでも退会することができます。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第11条（免責事項）</h2>
+    <p>本サービスは、安全性、正確性、完全性などについて一切保証しません。</p>
+    <p class="mt-2">当社は、ユーザーに生じた損害について、故意または重大な過失がない限り一切責任を負いません。</p>
+    <p class="mt-2">消費者契約法上の制限がある場合、当社の損害賠償責任は、利用料金の1ヶ月分または1万円のいずれか低い方を上限とします。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第12条（規約の変更）</h2>
+    <p>当社は、必要に応じて本規約を変更できます。変更後にサービスを利用した場合、変更後の規約に同意したものとみなします。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第13条（個人情報の取扱い）</h2>
+    <p>ユーザーの個人情報は、当社のプライバシーポリシーに従い適切に管理・利用されます。</p>
+  </section>
+
+  <section class="mb-12">
+    <h2 class="text-3xl font-bold mb-4">第14条（準拠法・裁判管轄）</h2>
+    <p>本規約は日本法に準拠します。また、本サービスに関して紛争が生じた場合には、当社本店所在地を管轄する地方裁判所を専属的合意管轄裁判所とします。</p>
+  </section>
+
+  <section>
+    <p class="mb-2">(2025年5月13日制定)</p>
+  </section>
+</div>

--- a/app/views/posts/_card.html.erb
+++ b/app/views/posts/_card.html.erb
@@ -18,7 +18,7 @@
         <%= link_to edit_post_path(post), id: "button-edit-#{post.id}", class: 'text-blue-500 hover:text-blue-700', data: { turbo: false } do %>
           <i class="bi bi-pencil-fill"></i>
         <% end %>
-        <%= link_to post_path(post), id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '削除しました', turbo: false }, class: 'text-red-500 hover:text-red-700' do %>
+        <%= link_to post_path(post), id: "button-delete-#{post.id}", data: { turbo_method: :delete, turbo_confirm: '削除しました', turbo: true }, class: 'text-red-500 hover:text-red-700' do %>
           <i class="bi bi-trash-fill"></i>
         <% end %>
       <% else %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -26,7 +26,7 @@
           <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}", class: 'text-blue-500 hover:text-blue-700' do %>
             <i class="bi bi-pencil-fill"></i>
           <% end %>
-          <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: '削除しました'}, class: 'text-red-500 hover:text-red-700' do %>
+          <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: '削除しました', turbo: true}, class: 'text-red-500 hover:text-red-700' do %>
             <i class="bi bi-trash-fill"></i>
           <% end %>
         <% else %>

--- a/app/views/top/index.html.erb
+++ b/app/views/top/index.html.erb
@@ -22,7 +22,9 @@
           <%= link_to "メッセージを振り返る(ユーザーページ)", userpages_path, class: 'inline-block text-base sm:text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
           <%= link_to "ワードを投稿する", posts_path, class: 'block text-center text-lg font-semibold text-blue-500 hover:text-blue-700 hover:underline' %>
           <%= link_to "アカウントを編集する", edit_user_registration_path, class: 'mt-6 inline-block text-sm sm:text-base font-medium text-white bg-indigo-500 hover:bg-indigo-600 px-4 py-2 rounded-full shadow-md' %>
-          <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'inline-block text-sm font-medium text-white bg-red-500 hover:bg-red-600 px-4 py-2 rounded-full shadow-md' %>
+          <%= button_to "ログアウト", destroy_user_session_path, method: :delete, class: 'mb-4 inline-block text-sm font-medium text-white bg-red-500 hover:bg-red-600 px-4 py-2 rounded-full shadow-md' %>
+          <%= link_to '利用規約', page_path('term_of_service') %>
+          <%= link_to 'プライバシーポリシー', page_path('policy') %>
         </div>
 
       <% else %>
@@ -42,6 +44,8 @@
                   devise_mapping: Devise.mappings[:user],
                   resource_class: User %>
           </div>
+          <%= link_to '利用規約', page_path('term_of_service') %>
+          <%= link_to 'プライバシーポリシー', page_path('policy') %>
         </div>
       <% end %>
     </div>

--- a/app/views/userpages/index.html.erb
+++ b/app/views/userpages/index.html.erb
@@ -18,7 +18,7 @@
 </button>
 
 <button data-tab="custom" class="tab-button py-2 px-10 font-semibold transition duration-300 ease-in-out focus:outline-none"
-        data-default-class="bg-green-50 text-gray-700 hover:bg-green-200"
+        data-default-class="bg-yellow-50 text-gray-700 hover:bg-yellow-200"
         aria-selected="<%= @active_tab == 'custom' %>">
   カスタム
 </button>


### PR DESCRIPTION
# 概要
**卒業制作⑪フロントエンドの強化**
利用規約、プライバシーポリシー

# 実装内容
- [x] 利用規約、プライバシーポリシーのページの実装
- gem 'high_voltage'を導入し、静的ページをルーティング設定などなしで実装可能に
- app/views/pages/policy.html.erb：プライバシーポリシーを追加
- app/views/pages/term_of_service.html.erb：利用規約を追加
- プライバシーポリシーと利用規約へのリンクを追加


# 確認方法
- [x] /page/policy、/page/term_of_serviceより利用規約、プライバシーポリシーを確認


# ISSUE
**Closes #75   **