### PR TITLE
i18n簡易対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,3 +87,5 @@ gem 'omniauth-google-oauth2'
 
 gem 'net-imap', '>= 0.5.7'
 
+gem 'devise-i18n'
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.13.0)
+      devise (>= 4.9.0)
+      rails-i18n
     diff-lcs (1.6.1)
     dockerfile-rails (1.7.9)
       rails (>= 3.0.0)
@@ -303,6 +306,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (8.0.1)
+      i18n (>= 0.7, < 2)
+      railties (>= 8.0.0, < 9)
     railties (8.0.2)
       actionpack (= 8.0.2)
       activesupport (= 8.0.2)
@@ -452,6 +458,7 @@ DEPENDENCIES
   config
   debug
   devise
+  devise-i18n
   dockerfile-rails (>= 1.7)
   dotenv-rails
   factory_bot_rails
@@ -461,17 +468,15 @@ DEPENDENCIES
   jbuilder
   kaminari
   letter_opener_web (~> 2.0)
-
+  net-imap (>= 0.5.7)
   omniauth-google-oauth2
   omniauth-line
   omniauth-rails_csrf_protection
-
-  net-imap (>= 0.5.7)
-
   pg (~> 1.1)
   pry
   puma (>= 5.0)
   rails (~> 8.0.2)
+  rails-i18n
   ransack (= 4.3.0)
   rspec-rails
   rubocop-rails-omakase

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,7 +1,7 @@
-<p><%= @email %> さん、ご登録ありがとうございます！</p>
+<p><%= @email %> さん、ご登録ありがとうございます</p>
 
 <p>ご利用を開始するには、以下のリンクからメールアドレスの確認をお願いします。</p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to 'メールアドレスを確認', confirmation_url(@resource, confirmation_token: @token) %></p>
 
 <p>引き続き 「ポジほめワード」よろしくお願いいたします。</p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,10 +1,10 @@
-<p><%= @resource.email %> さん、こんにちは。</p>
+<p><%= @resource.email %> さん</p>
 
 <p>パスワード再設定のリクエストがありました。</p>
 
 <p>新しいパスワードの設定は、以下のリンクから行えます。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to 'パスワードの変更', edit_password_url(@resource, reset_password_token: @token) %></p>
 
 <p>もしこの操作に心当たりがない場合は、このメールは無視していただいて大丈夫です。</p>
 <p>リンクにアクセスしない限り、パスワードは変更されませんのでご安心ください。</p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module Myapp
     config.time_zone = 'Asia/Tokyo' # アプリの内部処理タイムゾーン
     config.active_record.default_timezone = :local # DB保存タイムゾーン（ローカルならTokyo）
     config.active_support.to_time_preserves_timezone = :zone
+    config.i18n.default_locale = :ja
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
 

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,144 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user:
+        other: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: '以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。'
+        subject: 【ポジほめワード】メールアドレス確認をお願いします
+      email_changed:
+        greeting: "こんにちは、%{recipient}様。"
+        message: "メールアドレスの（%{email}）変更が完了したため、メールを送信しています。"
+        message_unconfirmed: "メールアドレスが（%{email}）変更されたため、メールを送信しています。"
+        subject: 【ポジほめワード】メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: 【ポジほめワード】パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: 'アカウントのロックを解除するには下のリンクをクリックしてください。'
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: 【ポジほめワード】アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: '%{email} の確認待ち'
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length:
+        other: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: "の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。"
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe User, type: :model do
         user2 = build(:user)
         user2.email = user1.email
         user2.valid?
-        expect(user2.errors[:email]).to include('has already been taken')
+        expect(user2.errors[:email]).to include('はすでに存在します')
       end
 
       it '無効なメール形式の場合、無効であること' do
@@ -52,7 +52,7 @@ RSpec.describe User, type: :model do
       it 'パスワードが6文字未満の場合、無効であること' do
         user = build(:user, password: 'short', password_confirmation: 'short')
         user.valid?
-        expect(user.errors[:password]).to include('is too short (minimum is 6 characters)')
+        expect(user.errors[:password]).to include('は6文字以上で入力してください')
       end
     end  
   end

--- a/spec/system/ai_messages_spec.rb
+++ b/spec/system/ai_messages_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'AiMessages', type: :system do
         visit '/ai_messages/new'
         Capybara.assert_current_path("/users/sign_in", ignore_query: true)
         expect(current_path).to eq('/users/sign_in'), 'ログインページにリダイレクトされていません'
-        expect(page).to have_content('You need to sign in or sign up before continuing.')
+        expect(page).to have_content('ログインもしくはアカウント登録してください。'), 'フラッシュメッセージ「ログインもしくはアカウント登録してください。」が表示されていません'
       end
     end
 
@@ -29,7 +29,7 @@ RSpec.describe 'AiMessages', type: :system do
         login_as(user)
         visit '/'
         click_on 'ポジティブワードを知る'
-        expect(page).to have_title("ワード生成 | ポジほめワード")
+        expect(page).to have_title("ワード生成 | ポジほめワード"), 'タイトル「ワード生成 | ポジほめワード」が表示されていません'
       end
 
       it 'メッセージの作成' do
@@ -38,7 +38,7 @@ RSpec.describe 'AiMessages', type: :system do
         fill_in '誰に送りますか', with: '自分自身'
         fill_in 'どんな時', with: '自分の成功を祝う'
         click_on 'ワードを作る'
-        expect(page).to have_content('ポジティブワード生成結果')
+        expect(page).to have_content('ポジティブワード生成結果'), 'ページ内に「ポジティブワード生成結果」が表示されていません'
       end
     end  
 
@@ -53,8 +53,8 @@ RSpec.describe 'AiMessages', type: :system do
           click_button '更新'
 
           Capybara.assert_current_path("/ai_messages/new", ignore_query: true)
-          expect(page).to have_text('ワードを編集しました')
-          expect(page).to have_content('編集ワード')
+          expect(page).to have_text('ワードを編集しました'), 'フラッシュメッセージ「ログインもしくはアカウント登録してください。」が表示されていません'
+          expect(page).to have_content('編集ワード'), 'ページ内に「編集ワード」が表示されていません'
         end
 
         it 'お気に入り登録・解除ができること' do
@@ -64,7 +64,7 @@ RSpec.describe 'AiMessages', type: :system do
           fill_in 'どんな時', with: '自分の成功を祝う'
           click_on 'ワードを作る'
 
-          expect(page).to have_content('ポジティブワード生成結果')
+          expect(page).to have_content('ポジティブワード生成結果'), 'ページ内に「ポジティブワード生成結果」が表示されていません'
 
           new_word = PositiveWord.order(created_at: :desc).first
           find('[data-testid="menu-toggle"]').click

--- a/spec/system/comment_spec.rb
+++ b/spec/system/comment_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Comments', type: :system do
   describe 'コメント一覧表示' do
     it '自分のコメントが表示される' do
       within '#table-comment' do
-        expect(page).to have_text(comment_by_me.body)
-        expect(page).to have_text(comment_by_me.user.username)
+        expect(page).to have_text(comment_by_me.body), 'コメントに「コメント内容」が表示されていません'
+        expect(page).to have_text(comment_by_me.user.username), 'コメントに「投稿者」が表示されていません'
       end
     end
   end
@@ -27,16 +27,16 @@ RSpec.describe 'Comments', type: :system do
         fill_in 'comment_body', with: '新規コメント'
         click_on '投稿'
 
-        expect(page).to have_text('コメントを投稿しました')
+        expect(page).to have_text('コメントを投稿しました'), 'フラッシュメッセージ「コメントを投稿しました」が表示されていません'
 
         comment = Comment.last
-        expect(comment.body).to eq('新規コメント')
-        expect(comment.user).to eq(user)
-        expect(comment.post).to eq(post)
+        expect(comment.body).to eq('新規コメント'), 'ページ内に「編集ワード」が表示されていません'
+        expect(comment.user).to eq(user), 'ページ内に「編集ワード」が表示されていません'
+        expect(comment.post).to eq(post), 'ページ内に「編集ワード」が表示されていません'
 
         within "#comment-#{comment.id}" do
-          expect(page).to have_text('新規コメント')
-          expect(page).to have_text(user.username)
+          expect(page).to have_text('新規コメント'), 'ページ内に「編集ワード」が表示されていません'
+          expect(page).to have_text(user.username), 'ページ内に「編集ワード」が表示されていません'
         end
       end
     end
@@ -47,7 +47,7 @@ RSpec.describe 'Comments', type: :system do
           fill_in 'comment_body', with: ''
           click_on '投稿'
         }.not_to change { Comment.count }
-        expect(page).to have_text('コメントを投稿できません')
+        expect(page).to have_text('コメントを投稿できません'), 'フラッシュメッセージ「コメントを投稿できません」が表示されていません'
       end
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe 'Comments', type: :system do
 
         expect(page).to have_current_path(post_path(post))
         within "#comment-#{editable_comment.id}" do
-          expect(page).to have_text('更新されたコメント')
+          expect(page).to have_text('更新されたコメント'), 'ページ内に「編集ワード」が表示されていません'
         end
       end
 
@@ -78,7 +78,7 @@ RSpec.describe 'Comments', type: :system do
           click_button class: 'delete-comment-button'
         end
 
-        expect(page).to have_text('コメントを削除しました')
+        expect(page).to have_text('コメントを削除しました'), 'フラッシュメッセージ「コメントを削除しました」が表示されていません'
         expect(page).not_to have_selector("#comment-#{editable_comment.id}")
       end
     end

--- a/spec/system/logins_spec.rb
+++ b/spec/system/logins_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe "ログイン機能", type: :system do
           click_button 'ログイン'
           Capybara.assert_current_path("/", ignore_query: true)
           expect(current_path).to eq '/'
+          expect(page).to have_content('ログインしました。'), 'フラッシュメッセージ「ログインしました。」が表示されていません'
         end
       end
 
@@ -44,7 +45,7 @@ RSpec.describe "ログイン機能", type: :system do
         find('#logout-button-desktop').click
         Capybara.assert_current_path("/", ignore_query: true)
         expect(current_path).to eq root_path
-        expect(page).to have_content('Signed out successfully.'), 'フラッシュメッセージ「Signed out successfully.」が表示されていません'
+        expect(page).to have_content('ログアウトしました。'), 'フラッシュメッセージ「ログアウトしました。」が表示されていません'
       end
     end
   end

--- a/spec/system/logins_spec.rb
+++ b/spec/system/logins_spec.rb
@@ -2,8 +2,6 @@ require 'rails_helper'
 
 RSpec.describe "ログイン機能", type: :system do
   let(:user) { create(:user) }
-
-  before { login(user) }
   
   describe '通常画面' do
     describe 'ログイン' do
@@ -42,7 +40,8 @@ RSpec.describe "ログイン機能", type: :system do
         login_as(user)
       end
       it 'ログアウトできること' do
-        find('#logout-button-desktop').click
+        visit '/'
+        find('#logout-button-desktop', match: :first).click
         Capybara.assert_current_path("/", ignore_query: true)
         expect(current_path).to eq root_path
         expect(page).to have_content('ログアウトしました。'), 'フラッシュメッセージ「ログアウトしました。」が表示されていません'

--- a/spec/system/positive_words_spec.rb
+++ b/spec/system/positive_words_spec.rb
@@ -15,6 +15,6 @@ RSpec.describe "PositiveWords", type: :system do
     select '自分の成功を祝う', from: 'situation_id'
     click_button '表示'
 
-    expect(page).to have_content('よく頑張ったね、これからが楽しみだ！')
+    expect(page).to have_content('よく頑張ったね、これからが楽しみだ！'), 'ページ内に「よく頑張ったね、これからが楽しみだ！」が表示されていません'
   end
 end

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'PostsPosts', type: :system do
           visit '/posts'
           Capybara.assert_current_path("/users/sign_in", ignore_query: true)
           expect(current_path).to eq('/users/sign_in'), 'ログインページにリダイレクトされていません'
-          expect(page).to have_content('You need to sign in or sign up before continuing.')
+          expect(page).to have_content('ログインもしくはアカウント登録してください。'), 'フラッシュメッセージ「ログインもしくはアカウント登録してください。」が表示されていません'
         end
       end
 
@@ -29,7 +29,7 @@ RSpec.describe 'PostsPosts', type: :system do
           login_as(user)
           visit '/'
           click_on 'ポジティブワードを共有する'
-          expect(page).to have_title("みんなのポジほめワード | ポジほめワード")
+          expect(page).to have_title("みんなのポジほめワード | ポジほめワード"), 'タイトル「みんなのポジほめワード | ポジほめワード」が表示されていません'
         end
 
         context '投稿ワードが一件もない場合' do
@@ -39,7 +39,7 @@ RSpec.describe 'PostsPosts', type: :system do
             click_on 'ポジティブワードを共有する'
             Capybara.assert_current_path("/posts", ignore_query: true)
             expect(current_path).to eq('/posts')
-            expect(page).to have_content('まだ投稿はありません。')
+            expect(page).to have_content('まだ投稿はありません。'), 'ページ内に「まだ投稿はありません。」が表示されていません'
           end
         end
 
@@ -49,9 +49,9 @@ RSpec.describe 'PostsPosts', type: :system do
             login_as(user)
             visit '/'
             click_on 'ポジティブワードを共有する'
-            expect(page).to have_content(post.post_word)
-            expect(page).to have_content(post.user.username)
-            expect(page).to have_content(post.caption)
+            expect(page).to have_content(post.post_word), 'ページ内に「投稿ワード」が表示されていません'
+            expect(page).to have_content(post.user.username), 'ページ内に「投稿者」が表示されていません'
+            expect(page).to have_content(post.caption), 'ページ内に「投稿の説明」が表示されていません'
           end
         end
 
@@ -81,10 +81,10 @@ RSpec.describe 'PostsPosts', type: :system do
       context 'ログインしていない場合' do
         it '投稿詳細が閲覧できること' do
           visit post_path(post)
-          expect(page).to have_content('投稿詳細')
-          expect(page).to have_content(post.post_word)
-          expect(page).to have_content(post.caption)
-          expect(page).to have_content(post.user.username)
+          expect(page).to have_content('投稿詳細'), 'ページ内に「投稿詳細」が表示されていません'
+          expect(page).to have_content(post.post_word), 'ページ内に「投稿ワード」が表示されていません'
+          expect(page).to have_content(post.caption), 'ページ内に「投稿の説明」が表示されていません'
+          expect(page).to have_content(post.user.username), 'ページ内に「投稿者」が表示されていません'
         end
       end
 
@@ -100,16 +100,16 @@ RSpec.describe 'PostsPosts', type: :system do
           first(:css, "#post-id-#{post.id} a", text: post.post_word).click
           Capybara.assert_current_path("/posts/#{post.id}", ignore_query: true)
           expect(current_path).to eq("/posts/#{post.id}")
-          expect(page).to have_content(post.post_word)
-          expect(page).to have_content(post.user.username)
-          expect(page).to have_content(post.caption)
+          expect(page).to have_content(post.post_word), 'ページ内に「投稿ワード」が表示されていません'
+          expect(page).to have_content(post.user.username), 'ページ内に「投稿者」が表示されていません'
+          expect(page).to have_content(post.caption), 'ページ内に「投稿の説明」が表示されていません'
         end
 
         it '正しいタイトルが表示されていること' do
           visit '/'
           click_on 'ポジティブワードを共有する'
           first(:css, "#post-id-#{post.id} a", text: post.post_word).click
-          expect(page).to have_title("#{post.post_word} | ポジほめワード")
+          expect(page).to have_title("#{post.post_word} | ポジほめワード"), 'タイトル「#{post.post_word} | ポジほめワード」が表示されていません'
         end
       end
     end
@@ -120,7 +120,7 @@ RSpec.describe 'PostsPosts', type: :system do
           visit '/posts/new'
           Capybara.assert_current_path("/users/sign_in", ignore_query: true)
           expect(current_path).to eq('/users/sign_in')
-          expect(page).to have_content('You need to sign in or sign up before continuing.')
+          expect(page).to have_content('ログインもしくはアカウント登録してください。'), 'フラッシュメッセージ「ログインもしくはアカウント登録してください。」が表示されていません'
         end
       end
 
@@ -135,7 +135,7 @@ RSpec.describe 'PostsPosts', type: :system do
           click_on '+ 新規投稿'
           Capybara.assert_current_path("/posts/new", ignore_query: true)
           expect(current_path).to eq('/posts/new')      
-          expect(page).to have_title("新規投稿 | ポジほめワード")
+          expect(page).to have_title("新規投稿 | ポジほめワード"), 'タイトル「新規投稿 | ポジほめワード」が表示されていません'
         end
 
         it '投稿できること' do
@@ -145,16 +145,16 @@ RSpec.describe 'PostsPosts', type: :system do
           click_button '投稿'
           Capybara.assert_current_path("/posts", ignore_query: true)
           expect(current_path).to eq('/posts')
-          expect(page).to have_content('投稿しました')
-          expect(page).to have_content('テストワード')
-          expect(page).to have_content('テストキャプション')
+          expect(page).to have_content('投稿しました'), 'フラッシュメッセージ「投稿しました」が表示されていません'
+          expect(page).to have_content('テストワード'), 'ページ内に「テストワード」が表示されていません'
+          expect(page).to have_content('テストキャプション'), 'ページ内に「テストキャプション」が表示されていません'
         end
 
         it '投稿に失敗すること' do          
           click_on '+ 新規投稿'
           fill_in 'ワードの説明', with: 'テストキャプション'
           click_button '投稿'
-          expect(page).to have_content('投稿できません')
+          expect(page).to have_content('投稿できません'), 'フラッシュメッセージ「投稿できません」が表示されていません'
         end
       end
     end
@@ -167,7 +167,7 @@ RSpec.describe 'PostsPosts', type: :system do
           visit edit_post_path(post)
           Capybara.assert_current_path("/users/sign_in", ignore_query: true)
           expect(current_path).to eq('/users/sign_in')
-          expect(page).to have_content('You need to sign in or sign up before continuing.')
+          expect(page).to have_content('ログインもしくはアカウント登録してください。'), 'フラッシュメッセージ「ログインもしくはアカウント登録してください。」が表示されていません'
         end
       end
 
@@ -185,16 +185,16 @@ RSpec.describe 'PostsPosts', type: :system do
             click_button '投稿'
             Capybara.assert_current_path("/posts/#{post.id}", ignore_query: true)
             expect(current_path).to eq post_path(post)
-            expect(page).to have_content('編集しました')
-            expect(page).to have_content('編集ワード')
-            expect(page).to have_content('編集キャプション')
+            expect(page).to have_content('編集しました'), 'フラッシュメッセージ「編集しました」が表示されていません'
+            expect(page).to have_content('編集ワード'), 'ページ内に「編集ワード」が表示されていません'
+            expect(page).to have_content('編集キャプション'), 'ページ内に「編集キャプション」が表示されていません'
           end
 
           it '編集に失敗すること' do
             fill_in '投稿したいワード', with: ''
             fill_in 'ワードの説明', with: ''
             click_button '投稿'
-            expect(page).to have_content('編集できません')
+            expect(page).to have_content('編集できません'), 'フラッシュメッセージ「編集できません」が表示されていません'
           end
         end
 
@@ -217,7 +217,7 @@ RSpec.describe 'PostsPosts', type: :system do
           visit '/posts'
           page.accept_confirm { find("#button-delete-#{post.id}").click }
           expect(current_path).to eq('/posts')
-          expect(page).to have_content('投稿を削除しました')
+          expect(page).to have_content('投稿を削除しました'), 'フラッシュメッセージ「投稿を削除しました」が表示されていません'
         end
       end
 
@@ -240,7 +240,7 @@ RSpec.describe 'PostsPosts', type: :system do
           click_on '★お気に入り'
           Capybara.assert_current_path("/posts/post_favorites", ignore_query: true)
           expect(current_path).to eq(favorites_posts_path)
-          expect(page).to have_content('お気に入り登録はありません')
+          expect(page).to have_content('お気に入り登録はありません'), 'ページ内に「お気に入り登録はありません」が表示されていません'
         end
       end
 
@@ -252,7 +252,9 @@ RSpec.describe 'PostsPosts', type: :system do
           click_on '★お気に入り'
           Capybara.assert_current_path("/posts/post_favorites", ignore_query: true)
           expect(current_path).to eq(favorites_posts_path)
-          expect(page).to have_content post.post_word
+          expect(page).to have_content(post.post_word), 'ページ内に「お気に入り登録したワード」が表示されていません'
+          expect(page).to have_content(post.caption), 'ページ内に「キャプション」が表示されていません'
+          expect(page).to have_content(post.user.username), 'ページ内に「投稿者」が表示されていません'
         end
       end
 

--- a/spec/system/registrations_spec.rb
+++ b/spec/system/registrations_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Registrations", type: :system do
 
     expect(page).to have_content('新規登録')
     expect(page).to have_selector('form')
+    expect(page).to have_title("新規登録 | ポジほめワード"), 'タイトル「新規登録 | ポジほめワード」が表示されていません'
   end
 
   it '新規登録が成功すること' do
@@ -20,7 +21,7 @@ RSpec.describe "Registrations", type: :system do
 
     click_button '登録'
     Capybara.assert_current_path("/", ignore_query: true)
-    expect(page).to have_content('Welcome! You have signed up successfully.')
+    expect(page).to have_content('アカウント登録が完了しました。'), 'フラッシュメッセージ「アカウント登録が完了しました。」が表示されていません'
   end
 
   it 'エラーメッセージが表示されること（無効なデータで登録）' do
@@ -45,6 +46,6 @@ RSpec.describe "Registrations", type: :system do
     fill_in 'user_password_confirmation', with: "password123"
 
     click_button '登録'
-    expect(page).to have_content("Email has already been taken")
+    expect(page).to have_content("Eメールはすでに存在します"), 'フラッシュメッセージ「Eメールはすでに存在します」が表示されていません'
   end
 end

--- a/spec/system/user_pages_spec.rb
+++ b/spec/system/user_pages_spec.rb
@@ -158,6 +158,7 @@ RSpec.describe "UserPages", type: :system do
         
         find('[data-testid="menu-toggle"]', wait: 5).click
         find(:css, "a[href='/word_favorites?positive_word_id=#{new_word.id}']").click
+        puts "生成されたワード: #{new_word.word}"
 
         visit userpages_path(tab: 'favorite')
         expect(page).to have_content(new_word.word, wait: 5)

--- a/spec/system/user_pages_spec.rb
+++ b/spec/system/user_pages_spec.rb
@@ -159,9 +159,8 @@ RSpec.describe "UserPages", type: :system do
         find('[data-testid="menu-toggle"]', wait: 5).click
         find(:css, "a[href='/word_favorites?positive_word_id=#{new_word.id}']").click
 
-
         visit userpages_path(tab: 'favorite')
-        expect(page).to have_content(new_word.word)
+        expect(page).to have_content(new_word.word, wait: 5)
         expect(page).not_to have_selector('.pagination'),'10件以下はページネーションが表示されない'
       end
 

--- a/spec/system/user_pages_spec.rb
+++ b/spec/system/user_pages_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "UserPages", type: :system do
         visit '/userpages'
         Capybara.assert_current_path("/users/sign_in", ignore_query: true)
         expect(current_path).to eq('/users/sign_in')
-        expect(page).to have_content('You need to sign in or sign up before continuing.')
+        expect(page).to have_content('ログインもしくはアカウント登録してください。'), 'フラッシュメッセージ「ログインもしくはアカウント登録してください。」が表示されていません'
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe "UserPages", type: :system do
 
       it 'ページタイトルが表示される', js: true do
         visit '/userpages'
-        expect(page).to have_title('ユーザーページ | ポジほめワード')
+        expect(page).to have_title('ユーザーページ | ポジほめワード'), 'タイトル「新規登録 | ポジほめワード」が表示されていません'
       end
     end
   end
@@ -37,7 +37,7 @@ RSpec.describe "UserPages", type: :system do
       it '何もない旨のメッセージが表示される', js: true do
         visit '/userpages?tab=all'
         expect(page).to have_selector("[data-tab-content='all']", visible: true)
-        expect(page).to have_content('登録されたワードはありません')
+        expect(page).to have_content('登録されたワードはありません'), 'ページ内に「登録されたワードはありません」が表示されていません'
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe "UserPages", type: :system do
         within '[data-tab-content="all"]' do
           fill_in 'ワードを入力', with: 'カスタムワード'
           click_button '追加'
-          expect(page).to have_content('カスタムワード')
+          expect(page).to have_content('カスタムワード'), 'ページ内に「カスタムワード」が表示されていません'
         end
       end
     end
@@ -64,7 +64,7 @@ RSpec.describe "UserPages", type: :system do
         visit '/userpages?tab=custom'
         find("[data-tab='custom']", wait: 5).click
         expect(page).to have_selector("[data-tab-content='custom']", visible: true)
-        expect(page).to have_content('カスタムワードはありません')
+        expect(page).to have_content('カスタムワードはありません'), 'ページ内に「カスタムワードはありません」が表示されていません'
       end
     end
 
@@ -115,8 +115,8 @@ RSpec.describe "UserPages", type: :system do
 
         Capybara.assert_current_path("/userpages", ignore_query: true)
         expect(current_path).to eq('/userpages')
-        expect(page).to have_text('カスタムワードを編集しました')
-        expect(page).to have_content('編集カスタムワード')
+        expect(page).to have_text('カスタムワードを編集しました'), 'フラッシュメッセージ「カスタムワードを編集しました」が表示されていません'
+        expect(page).to have_content('編集カスタムワード'), 'ページ内に「編集カスタムワード」が表示されていません'
       end
 
       it 'カスタムワードが削除できること', js: true do
@@ -128,8 +128,8 @@ RSpec.describe "UserPages", type: :system do
           find("button", text: '削除', wait: 5).click
         end
 
-        expect(page).to have_text('ワードを削除しました')
-        expect(page).not_to have_content('削除対象')
+        expect(page).to have_text('ワードを削除しました'), 'フラッシュメッセージ「ワードを削除しました」が表示されていません'
+        expect(page).not_to have_content('削除対象'), 'ページ内に「削除対象」が表示されていません'
       end
     end
   end
@@ -141,7 +141,7 @@ RSpec.describe "UserPages", type: :system do
       it 'メッセージが表示される', js: true do
         visit userpages_path(tab: 'favorite')
         find("[data-tab='favorite']", wait: 5).click
-        expect(page).to have_content('お気に入り登録はありません')
+        expect(page).to have_content('お気に入り登録はありません'), 'ページ内に「お気に入り登録はありません」が表示されていません'
       end
     end
 
@@ -153,7 +153,7 @@ RSpec.describe "UserPages", type: :system do
         fill_in 'どんな時', with: '励ましたい時'
         click_button 'ワードを作る'
 
-        expect(page).to have_content('ポジティブワード生成結果')
+        expect(page).to have_content('ポジティブワード生成結果'), 'ページ内に「ポジティブワード生成結果」が表示されていません'
         new_word = PositiveWord.order(created_at: :desc).first
         
         find('[data-testid="menu-toggle"]', wait: 5).click
@@ -198,8 +198,8 @@ RSpec.describe "UserPages", type: :system do
         click_button '更新'
 
         Capybara.assert_current_path("/userpages", ignore_query: true)
-        expect(page).to have_text('ワードを編集しました')
-        expect(page).to have_content('編集後のワード')
+        expect(page).to have_text('ワードを編集しました'), 'フラッシュメッセージ「ワードを編集しました」が表示されていません'
+        expect(page).to have_content('編集後のワード'), 'ページ内に「編集後のワード」が表示されていません'
       end
     end
   end


### PR DESCRIPTION
# 概要
**卒業制作⑬外部SNS等の連携**
i18n簡易対応

# 実装内容
**実装内容**
- [x] gem deviseをi18nで日本語化
- Gemfileにgem 'devise-i18n'を導入
- config/application.rbに  config.i18n.default_locale = :jaでデフォルト言語を日本語に
- rails g devise:i18n:locale jaを実行し表示される日本語を編集
- [x] テストコードを日本語に対応

# 確認方法
- [x] 新規登録、ログイン関係が日本語になっているか確認


# ISSUE
**Closes #103   **